### PR TITLE
Proposed fix for failure to present new character groups in generator…

### DIFF
--- a/Software/src/morse_3_v2.0/morse_3_v2.0.ino
+++ b/Software/src/morse_3_v2.0/morse_3_v2.0.ino
@@ -1373,7 +1373,9 @@ void loop() {
                                printOnStatusLine(true, 0, "Continue w/ Paddle");
                             }
                           else {
-                               cleanStartSettings();        
+                               //cleanStartSettings();        
+                               generatorState = KEY_UP; 
+                               genTimer = millis()-1;           // we will be at end of KEY_DOWN when called the first time, so we can fetch a new word etc...          
                             }
                           }
                           if (active)


### PR DESCRIPTION
This commit should fix the problem that in generator mode only vvv<ka> is sent when auto stop is on.