### PR TITLE
Feature/jw/improve paddle iambic key timing

### DIFF
--- a/Software/src/morse_3_v2.3/morse_3_v2.3.ino
+++ b/Software/src/morse_3_v2.3/morse_3_v2.3.ino
@@ -1346,7 +1346,6 @@ void loop() {
    int t;
 
    //boolean activeOld = active;
-   checkPaddles();
    switch (morseState) {
       case morseKeyer:    if (doPaddleIambic(leftKey, rightKey)) {
                                return;                                                        // we are busy keying and so need a very tight loop !
@@ -1448,6 +1447,7 @@ void loop() {
                         
   } // end switch and code depending on state of metaMorserino
 
+  checkPaddles();
 /// if we have time check for button presses
 
     modeButton.Update();
@@ -2041,7 +2041,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
          } 
          return false;                // we return false if there was no paddle press in IDLE STATE - Arduino can do other tasks for a bit
         }
-        break;
+        return true;
 
     case DIT:
     /// first we check that we have waited as defined by ACS settings
@@ -2062,7 +2062,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                              break;
             }
             keyerState = KEY_START;                          // set next state of state machine
-            break;
+            return true;
             
     case DAH:
             if ( p_ACSlength > 0 && (millis() <= acsTimer))  // if we do automatic character spacing, and haven't waited for 3 dits...
@@ -2082,7 +2082,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                              break;
             }
             keyerState = KEY_START;                          // set next state of state machine
-            break;
+            return true;
      
 
       
@@ -2094,7 +2094,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
            ktimer += millis();                     // set ktimer to interval end time          
            curtistimer += millis();                // set curtistimer to curtis end time
            keyerState = KEYED;                     // next state
-           break;
+           return true;
  
     case KEYED:
                                                    // Wait for timers to expire
@@ -2114,7 +2114,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                     updatePaddleLatch(dit, false);  
                  // updatePaddleLatch(dit, dah);       // but we remain in the same state until element time is off! 
             }
-            break;
+            return true;
  
     case INTER_ELEMENT:
             //if ((p_keyermode != NONSQUEEZE) && (millis() < latencytimer)) {     // or should it be p_keyermode > 2 ? Latency for Ultimatic mode?
@@ -2124,9 +2124,11 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
               else
                     updatePaddleLatch(dit, false);
               // updatePaddleLatch(dit, dah); 
+              return false; 
             }
             else if (millis() < tailMuteTimer) {
               updatePaddleLatch(dit, dah);          // latch paddle state while between elements 
+              return false;
             }
             else {
                 if (millis() >= ktimer) {               // at end of INTER-ELEMENT
@@ -2190,13 +2192,10 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                           break;
                     } // switch keyerControl : evaluation of flags
                 }
+            return true;
             } // end of INTER_ELEMENT
   } // end switch keyerState - end of state machine
 
-  if (keyerControl & 3)                                               // any paddle latch?                            
-    return true;                                                      // we return true - we processed a paddle press
-  else
-    return false;                                                     // when paddle latches are cleared, we return false
 } /////////////////// end function doPaddleIambic()
 
 

--- a/Software/src/morse_3_v2.3/morse_3_v2.3.ino
+++ b/Software/src/morse_3_v2.3/morse_3_v2.3.ino
@@ -1986,6 +1986,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
   static long curtistimer;                 // timer for early paddle latch in Curtis mode B+
   static long latencytimer;                // timer for "muting" paddles for some time in state INTER_ELEMENT
   unsigned int pitch;
+  static long latency;
 
   if (!p_didah)   {              // swap left and right values if necessary!
       paddleSwap = dit; dit = dah; dah = paddleSwap; 
@@ -2011,6 +2012,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
              }
          }
         
+         latency = ((p_latency-1) * ditLength / 8);
        // Was there a paddle press?
         if (dit || dah ) {
             updatePaddleLatch(dit, dah);  // trigger the paddle latches
@@ -2099,7 +2101,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                //pwmNoTone();                      // stop side tone
                keyOut(false, true, 0, 0);
                ktimer = millis() + ditLength;    // inter-element time
-               latencytimer = millis() + ((p_latency-1) * ditLength / 8);
+               latencytimer = millis() + latency;
                keyerState = INTER_ELEMENT;       // next state
             }
             else if (millis() > curtistimer ) {     // in Curtis mode we check paddle as soon as Curtis time is off

--- a/Software/src/morse_3_v2.3/morse_3_v2.3.ino
+++ b/Software/src/morse_3_v2.3/morse_3_v2.3.ino
@@ -1985,8 +1985,10 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
   static long ktimer;                      // timer for current element (dit or dah)
   static long curtistimer;                 // timer for early paddle latch in Curtis mode B+
   static long latencytimer;                // timer for "muting" paddles for some time in state INTER_ELEMENT
+  static long tailMuteTimer;                   //timer for muting padded at end of INTER_ELEMENT
   static unsigned int pitch;
   static long latency;
+  static long tailMuteInMilliseconds = 2;
 
   if (!p_didah)   {              // swap left and right values if necessary!
       paddleSwap = dit; dit = dah; dah = paddleSwap; 
@@ -2102,6 +2104,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                keyOut(false, true, 0, 0);
                ktimer = millis() + ditLength;    // inter-element time
                latencytimer = millis() + latency;
+               tailMuteTimer = millis() + ditLength - tailMuteInMilliseconds;
                keyerState = INTER_ELEMENT;       // next state
             }
             else if (millis() > curtistimer ) {     // in Curtis mode we check paddle as soon as Curtis time is off
@@ -2122,8 +2125,10 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                     updatePaddleLatch(dit, false);
               // updatePaddleLatch(dit, dah); 
             }
+            else if (millis() < tailMuteTimer) {
+              updatePaddleLatch(dit, dah);          // latch paddle state while between elements 
+            }
             else {
-                updatePaddleLatch(dit, dah);          // latch paddle state while between elements       
                 if (millis() >= ktimer) {               // at end of INTER-ELEMENT
                     switch(keyerControl) {
                           case 3:                                         // both paddles are latched

--- a/Software/src/morse_3_v2.3/morse_3_v2.3.ino
+++ b/Software/src/morse_3_v2.3/morse_3_v2.3.ino
@@ -2094,7 +2094,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
  
     case KEYED:
                                                    // Wait for timers to expire
-           if (millis() > ktimer) {                // are we at end of key down ?
+           if (millis() >= ktimer) {                // are we at end of key down ?
                //digitalWrite(keyerPin, LOW);        // turn the LED off, unkey transmitter, or whatever
                //pwmNoTone();                      // stop side tone
                keyOut(false, true, 0, 0);
@@ -2122,7 +2122,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
             }
             else {
                 updatePaddleLatch(dit, dah);          // latch paddle state while between elements       
-                if (millis() > ktimer) {               // at end of INTER-ELEMENT
+                if (millis() >= ktimer) {               // at end of INTER-ELEMENT
                     switch(keyerControl) {
                           case 3:                                         // both paddles are latched
                           case 7: 

--- a/Software/src/morse_3_v2.3/morse_3_v2.3.ino
+++ b/Software/src/morse_3_v2.3/morse_3_v2.3.ino
@@ -1985,7 +1985,7 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
   static long ktimer;                      // timer for current element (dit or dah)
   static long curtistimer;                 // timer for early paddle latch in Curtis mode B+
   static long latencytimer;                // timer for "muting" paddles for some time in state INTER_ELEMENT
-  unsigned int pitch;
+  static unsigned int pitch;
   static long latency;
 
   if (!p_didah)   {              // swap left and right values if necessary!
@@ -2012,6 +2012,10 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
              }
          }
         
+         pitch = notes[p_sidetoneFreq];
+         if ((morseState == echoTrainer || morseState == loraTrx) && p_echoToneShift != 0) {
+           pitch = (p_echoToneShift == 1 ? pitch * 18 / 17 : pitch * 17 / 18);        /// one half tone higher or lower, as set in parameters in echo trainer mode
+         }
          latency = ((p_latency-1) * ditLength / 8);
        // Was there a paddle press?
         if (dit || dah ) {
@@ -2082,10 +2086,6 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
       
     case KEY_START:
           // Assert key down, start timing, state shared for dit or dah
-          pitch = notes[p_sidetoneFreq];
-          if ((morseState == echoTrainer || morseState == loraTrx) && p_echoToneShift != 0) {
-             pitch = (p_echoToneShift == 1 ? pitch * 18 / 17 : pitch * 17 / 18);        /// one half tone higher or lower, as set in parameters in echo trainer mode
-          }
            //pwmTone(pitch, p_sidetoneVolume, true);
            //keyTransmitter();
            keyOut(true, true, pitch, p_sidetoneVolume);


### PR DESCRIPTION
This PR contains several commits where each can be viewed separately. Each should improve the signal timing during iambic paddling.

The recommended dit pattern test using audacity to monitor the audio output was performed. The results of the final test with all commits was as follows:

![Screen Shot 2020-02-29 at 10 30 59 AM](https://user-images.githubusercontent.com/59789483/75611456-4d0b9400-5ae0-11ea-804b-beaff6e28b01.png)

