### PR TITLE
WiFiTrx: Add DNS support to Wifi TRX mode and use src port 7373

### DIFF
--- a/Software/src/morse_3_v3.0/MorseWiFi.cpp
+++ b/Software/src/morse_3_v3.0/MorseWiFi.cpp
@@ -22,8 +22,7 @@
 // File file;
 
 WebServer MorseWiFi::server(80);    // Create a webserver object that listens for HTTP request on port 80
-WiFiUDP MorseWiFi::udp;             // Create udp socket for wifi tx
-AsyncUDP MorseWiFi::audp;           // Create async udp socket for wifi rx
+AsyncUDP MorseWiFi::audp;           // Create async udp socket for wifi trx
 
 File MorseWiFi::fsUploadFile;              // a File object to temporarily store the received file
 

--- a/Software/src/morse_3_v3.0/MorseWiFi.cpp
+++ b/Software/src/morse_3_v3.0/MorseWiFi.cpp
@@ -44,7 +44,7 @@ const char* MorseWiFi::myForm = "<html><head><meta charset='utf-8'><title>Get AP
                 "<input name='ssid' id='ssid' value='SSIDV'></div> <div>"
                 "<label for='pw'>WiFi Password?</label>"
                 "<input name='pw' id='pw'></div> <div>"
-                "<label for='trxpeer'>WiFi TRX Peer IP?</label>" 
+                "<label for='trxpeer'>WiFi TRX Peer IP/Host?</label>" 
                 "<input name='trxpeer' id='trxpeer' value='PEERIPV'>"
                 "</div><div>(255.255.255.255 = Local Broadcast IP will be used as Peer if empty)"
                 "</div><div><button>Submit</button></div></form></body></html>";

--- a/Software/src/morse_3_v3.0/MorseWiFi.h
+++ b/Software/src/morse_3_v3.0/MorseWiFi.h
@@ -12,7 +12,6 @@ namespace MorseWiFi
     ////////////////// Variables for file handling and WiFi functions
 
     extern WebServer server;    
-    extern WiFiUDP udp;             
     extern AsyncUDP audp;         
     
     extern File fsUploadFile;              // a File object to temporarily store the received file

--- a/Software/src/morse_3_v3.0/morse_3_v3.0.ino
+++ b/Software/src/morse_3_v3.0/morse_3_v3.0.ino
@@ -1861,12 +1861,16 @@ void sendWithLora() {           // hand this string over as payload to the LoRA 
 
 void sendWithWifi() {           // hand this string over as payload to the WiFi transceiver
   // send packet
-  const char* peerIp = MorsePreferences::wlanTRXPeer.c_str();
+  const char* peerHost = MorsePreferences::wlanTRXPeer.c_str();
+  IPAddress peerIP;
   if (MorsePreferences::wlanTRXPeer.length() == 0) {
-  peerIp = "255.255.255.255"; // send to local broadcast IP if not set
+      peerHost = "255.255.255.255"; // send to local broadcast IP if not set
+  }
+  if (!peerIP.fromString(peerHost)) {    // try to interpret the peer as an ip address...
+      WiFi.hostByName(peerHost, peerIP); // ...and resolve peer into ip address if that fails
   }
   //DEBUG("Send with WiFi! " + String(cwTxBuffer));
-  MorseWiFi::udp.beginPacket(peerIp, MORSERINOPORT);
+  MorseWiFi::udp.beginPacket(peerIP, MORSERINOPORT);
   MorseWiFi::udp.print(cwTxBuffer);
   MorseWiFi::udp.endPacket();
 }

--- a/Software/src/morse_3_v3.0/morse_3_v3.0.ino
+++ b/Software/src/morse_3_v3.0/morse_3_v3.0.ino
@@ -34,7 +34,7 @@
 #include "english_words.h"    // common English words
 #include "MorseOutput.h"      // display and sound functions
 #include "MorsePreferences.h" // preferences and persistent storage, snapshots
-#include "morseMenu.h"        // main menu
+#include "MorseMenu.h"        // main menu
 #include "MorseWiFi.h"        // WiFi functions
 #include "goertzel.h"         // Goertzel filter
 #include "MorseDecoder.h"     // Decoder Engine

--- a/Software/src/morse_3_v3.0/morse_3_v3.0.ino
+++ b/Software/src/morse_3_v3.0/morse_3_v3.0.ino
@@ -1870,9 +1870,7 @@ void sendWithWifi() {           // hand this string over as payload to the WiFi 
       WiFi.hostByName(peerHost, peerIP); // ...and resolve peer into ip address if that fails
   }
   //DEBUG("Send with WiFi! " + String(cwTxBuffer));
-  MorseWiFi::udp.beginPacket(peerIP, MORSERINOPORT);
-  MorseWiFi::udp.print(cwTxBuffer);
-  MorseWiFi::udp.endPacket();
+  MorseWiFi::audp.writeTo((uint8_t*)cwTxBuffer, strlen(cwTxBuffer), peerIP, MORSERINOPORT);
 }
 
 void onLoraReceive(int packetSize){


### PR DESCRIPTION
Now a user can use a hostname (eg a dyndns address) as a peer.
Also the source port is now `7373` as well which might help to pass through a NAT.
Also compiling was fixed on case sensitive file systems.

This has not yet been tested with two morserinos. Only with one using wireshark to verify the network traffic!