### PR TITLE
Support multiple wifi network configs

### DIFF
--- a/Software/src/morse_3_v3.0/MorseMenu.cpp
+++ b/Software/src/morse_3_v3.0/MorseMenu.cpp
@@ -21,7 +21,7 @@ using namespace MorseMenu;
 //////// variables and constants for the modus menu
 
 
-const uint8_t menuN = 41;     // no of menu items +1
+const uint8_t menuN = 42;     // no of menu items +1
 
 const String menuText [menuN] = {
   "",
@@ -70,9 +70,10 @@ const String menuText [menuN] = {
     "Check WiFi",
     "Upload File",
     "Update Firmw", //39
+    "Wifi Select", //40
   
   
-  "Go To Sleep" } ; // 40
+  "Go To Sleep" } ; // 41
 
 enum navi {naviLevel, naviLeft, naviRight, naviUp, naviDown };
        
@@ -113,12 +114,13 @@ const uint8_t menuNav [menuN] [5] = {                   // { level, left, right,
   {1,_trxWifi,_trxLora,_trx,0},                         // 32 icw
   {0,_trx,_wifi,_dummy,0},                              // 33 decoder
   {0,_decode,_goToSleep,_dummy,_wifi_mac},              // 34 WiFi
-  {1,_wifi_update,_wifi_config,_wifi,0},                // 35 Disp Mac
+  {1,_wifi_select,_wifi_config,_wifi,0},                // 35 Disp Mac
   {1,_wifi_mac,_wifi_check,_wifi,0},                    // 36 Config Wifi
   {1,_wifi_config,_wifi_upload,_wifi,0},                // 37 Check WiFi
   {1,_wifi_check,_wifi_update,_wifi,0},                 // 38 Upload File
-  {1,_wifi_upload,_wifi_mac,_wifi,0},                   // 39 Update Firmware
-  {0,_wifi,_keyer,_dummy,0}                             // 40 goto sleep
+  {1,_wifi_upload,_wifi_select,_wifi,0},                // 39 Update Firmware
+  {1,_wifi_update,_wifi_mac,_wifi,0},                   // 40 Select network
+  {0,_wifi,_keyer,_dummy,0}                             // 41 goto sleep
 };
 
 //boolean quickStart;                                     // should we execute menu item immediately?
@@ -436,6 +438,9 @@ boolean MorseMenu::menuExec() {                                          // retu
       case _wifi_upload:
       case _wifi_update:
                   MorseWiFi::menuExec((uint8_t) MorsePreferences::menuPtr);
+                  break;
+      case _wifi_select:
+                  MorseWiFi::menuNetSelect();
                   break;
       case  _goToSleep: /// deep sleep
                 checkShutDown(true);

--- a/Software/src/morse_3_v3.0/MorsePreferences.cpp
+++ b/Software/src/morse_3_v3.0/MorsePreferences.cpp
@@ -81,6 +81,16 @@ Preferences pref;               // use the Preferences library for storing and r
   String  MorsePreferences::wlanSSID = "";                    // SSID for connecting to the Internet
   String  MorsePreferences::wlanPassword = "";                // password for connecting to WiFi router
   String  MorsePreferences::wlanTRXPeer = "";                 // peer Morserino for WiFI TRX
+  String  MorsePreferences::wlanSSID1 = "";                    // SSID for connecting to the Internet
+  String  MorsePreferences::wlanPassword1 = "";                // password for connecting to WiFi router
+  String  MorsePreferences::wlanTRXPeer1 = "";                 // peer Morserino for WiFI TRX
+  String  MorsePreferences::wlanSSID2 = "";                    // SSID for connecting to the Internet
+  String  MorsePreferences::wlanPassword2 = "";                // password for connecting to WiFi router
+  String  MorsePreferences::wlanTRXPeer2 = "";                 // peer Morserino for WiFI TRX
+  String  MorsePreferences::wlanSSID3 = "";                    // SSID for connecting to the Internet
+  String  MorsePreferences::wlanPassword3 = "";                // password for connecting to WiFi router
+  String  MorsePreferences::wlanTRXPeer3 = "";                 // peer Morserino for WiFI TRX
+
   uint32_t MorsePreferences::fileWordPointer = 0;             // remember how far we have read the file in player mode / reset when loading new file         
   uint8_t MorsePreferences::promptPause = 2;                  // in echoTrainer mode, length of pause before we send next word; multiplied by interWordSpace
   uint8_t MorsePreferences::tLeft = 20;                       // threshold for left paddle
@@ -1225,6 +1235,17 @@ void MorsePreferences::readPreferences(String repository) {
     MorsePreferences::wlanSSID = pref.getString("wlanSSID");
     MorsePreferences::wlanPassword = pref.getString("wlanPassword");
     MorsePreferences::wlanTRXPeer = pref.getString("wlanTRXPeer", "");
+
+    MorsePreferences::wlanSSID1 = pref.getString("wlanSSID1");
+    MorsePreferences::wlanPassword1 = pref.getString("wlanPassword1");
+    MorsePreferences::wlanTRXPeer1 = pref.getString("wlanTRXPeer1", "");
+    MorsePreferences::wlanSSID2 = pref.getString("wlanSSID2");
+    MorsePreferences::wlanPassword2 = pref.getString("wlanPassword2");
+    MorsePreferences::wlanTRXPeer2 = pref.getString("wlanTRXPeer2", "");
+    MorsePreferences::wlanSSID3 = pref.getString("wlanSSID3");
+    MorsePreferences::wlanPassword3 = pref.getString("wlanPassword3");
+    MorsePreferences::wlanTRXPeer3 = pref.getString("wlanTRXPeer3", "");
+
     MorsePreferences::lcwoKochSeq = pref.getBool("lcwoKochSeq");
     MorsePreferences::useCustomCharSet = pref.getBool("useCustomChar");
     MorsePreferences::customCharSet = pref.getString("customCharSet", "");
@@ -1361,6 +1382,26 @@ void MorsePreferences::writePreferences(String repository) {
     if (MorsePreferences::wlanTRXPeer != pref.getString("wlanTRXPeer"))
         pref.putString("wlanTRXPeer", MorsePreferences::wlanTRXPeer);
 
+    if (MorsePreferences::wlanSSID1 != pref.getString("wlanSSID1"))
+        pref.putString("wlanSSID1", MorsePreferences::wlanSSID1);
+    if (MorsePreferences::wlanPassword1 != pref.getString("wlanPassword1"))
+        pref.putString("wlanPassword1", MorsePreferences::wlanPassword1);
+    if (MorsePreferences::wlanTRXPeer1 != pref.getString("wlanTRXPeer1"))
+        pref.putString("wlanTRXPeer1", MorsePreferences::wlanTRXPeer1);
+
+    if (MorsePreferences::wlanSSID2 != pref.getString("wlanSSID2"))
+        pref.putString("wlanSSID2", MorsePreferences::wlanSSID2);
+    if (MorsePreferences::wlanPassword2 != pref.getString("wlanPassword2"))
+        pref.putString("wlanPassword2", MorsePreferences::wlanPassword2);
+    if (MorsePreferences::wlanTRXPeer2 != pref.getString("wlanTRXPeer2"))
+        pref.putString("wlanTRXPeer2", MorsePreferences::wlanTRXPeer2);
+
+    if (MorsePreferences::wlanSSID3 != pref.getString("wlanSSID3"))
+        pref.putString("wlanSSID3", MorsePreferences::wlanSSID3);
+    if (MorsePreferences::wlanPassword3 != pref.getString("wlanPassword3"))
+        pref.putString("wlanPassword3", MorsePreferences::wlanPassword3);
+    if (MorsePreferences::wlanTRXPeer3 != pref.getString("wlanTRXPeer3"))
+        pref.putString("wlanTRXPeer3", MorsePreferences::wlanTRXPeer3);
 
     if (! morserino)  {
         pref.putUChar("lastExecuted", MorsePreferences::menuPtr);   // store last executed command in snapshots
@@ -1510,6 +1551,61 @@ void MorsePreferences::writeLastExecuted(uint8_t menuPtr)
     pref.begin("morserino", false);             // open the namespace as read/write
     pref.putUChar("lastExecuted", menuPtr);   // store last executed command
     pref.end();                                 // close namespace
+}
+
+void MorsePreferences::writeWifiInfoMultiple(
+  String ssid1, String passwd1, String trxpeer1,
+  String ssid2, String passwd2, String trxpeer2,
+  String ssid3, String passwd3, String trxpeer3
+  )
+{
+    pref.begin("morserino", false);             // open the namespace as read/write
+
+    if (ssid1 != "")
+      MorsePreferences::wlanSSID1 = ssid1;
+    if (passwd1 != "")
+      MorsePreferences::wlanPassword1 = passwd1;
+    //if (trxpeer != "")
+      MorsePreferences::wlanTRXPeer1 = trxpeer1;
+
+    if (MorsePreferences::wlanSSID1 != pref.getString("wlanSSID1"))
+        pref.putString("wlanSSID1", MorsePreferences::wlanSSID1);
+    if (MorsePreferences::wlanPassword1 != pref.getString("wlanPassword1"))
+        pref.putString("wlanPassword1", MorsePreferences::wlanPassword1);
+    if (MorsePreferences::wlanTRXPeer1 != pref.getString("wlanTRXPeer1"))
+        pref.putString("wlanTRXPeer1", MorsePreferences::wlanTRXPeer1);
+
+    if (ssid2 != "")
+      MorsePreferences::wlanSSID2 = ssid2;
+    if (passwd2 != "")
+      MorsePreferences::wlanPassword2 = passwd2;
+    //if (trxpeer != "")
+      MorsePreferences::wlanTRXPeer2 = trxpeer2;
+
+    if (MorsePreferences::wlanSSID2 != pref.getString("wlanSSID2"))
+        pref.putString("wlanSSID2", MorsePreferences::wlanSSID2);
+    if (MorsePreferences::wlanPassword2 != pref.getString("wlanPassword2"))
+        pref.putString("wlanPassword2", MorsePreferences::wlanPassword2);
+    if (MorsePreferences::wlanTRXPeer2 != pref.getString("wlanTRXPeer2"))
+        pref.putString("wlanTRXPeer2", MorsePreferences::wlanTRXPeer2);
+
+    if (ssid3 != "")
+      MorsePreferences::wlanSSID3 = ssid3;
+    if (passwd3 != "")
+      MorsePreferences::wlanPassword3 = passwd3;
+    //if (trxpeer != "")
+      MorsePreferences::wlanTRXPeer3 = trxpeer3;
+
+    if (MorsePreferences::wlanSSID3 != pref.getString("wlanSSID3"))
+        pref.putString("wlanSSID3", MorsePreferences::wlanSSID3);
+    if (MorsePreferences::wlanPassword3 != pref.getString("wlanPassword3"))
+        pref.putString("wlanPassword3", MorsePreferences::wlanPassword3);
+    if (MorsePreferences::wlanTRXPeer3 != pref.getString("wlanTRXPeer3"))
+        pref.putString("wlanTRXPeer3", MorsePreferences::wlanTRXPeer3);
+
+    pref.end();
+
+    writeWifiInfo(ssid1, passwd1, trxpeer1);
 }
 
 void MorsePreferences::writeWifiInfo(String ssid, String passwd, String trxpeer)

--- a/Software/src/morse_3_v3.0/MorsePreferences.h
+++ b/Software/src/morse_3_v3.0/MorsePreferences.h
@@ -80,9 +80,24 @@ namespace MorsePreferences
   extern uint8_t responsePause;
   extern uint8_t wpm;
   extern uint8_t menuPtr;
+  //current network config
   extern String  wlanSSID;
   extern String  wlanPassword;
   extern String  wlanTRXPeer; 
+
+  // config for up to three networks
+  extern String  wlanSSID1;
+  extern String  wlanPassword1;
+  extern String  wlanTRXPeer1; 
+  
+  extern String  wlanSSID2;
+  extern String  wlanPassword2;
+  extern String  wlanTRXPeer2; 
+  
+  extern String  wlanSSID3;
+  extern String  wlanPassword3;
+  extern String  wlanTRXPeer3; 
+
   extern uint32_t fileWordPointer;
   extern uint8_t promptPause;
   extern uint8_t tLeft;
@@ -173,6 +188,7 @@ namespace MorsePreferences
   void writeVolume();
   void writeLastExecuted(uint8_t menuPtr);
   void writeWifiInfo(String, String, String);
+  void writeWifiInfoMultiple(String, String, String, String, String, String, String, String, String);
   void fireCharSeen(boolean wpmOnly);
   void setCurrentOptions(prefPos *current, int size);
 }

--- a/Software/src/morse_3_v3.0/MorseWiFi.cpp
+++ b/Software/src/morse_3_v3.0/MorseWiFi.cpp
@@ -38,16 +38,63 @@ const char* MorseWiFi::password = "";
 // HTML for the AP server - used to get SSID and Password for local WiFi network - needed for file upload and OTA SW updates
 const char* MorseWiFi::myForm = "<html><head><meta charset='utf-8'><title>Get AP Info</title><style> form {width: 420px;}div { margin-bottom: 20px;}"
                 "label {display: inline-block; width: 240px; text-align: right; padding-right: 10px;} button, input {float: right;}</style>"
-                "</head><body>"
-                "<form action='/set' method='get'><div>"
-                "<label for='ssid'>SSID of WiFi network?</label>"
-                "<input name='ssid' id='ssid' value='SSIDV'></div> <div>"
-                "<label for='pw'>WiFi Password?</label>"
-                "<input name='pw' id='pw'></div> <div>"
-                "<label for='trxpeer'>WiFi TRX Peer IP/Host?</label>" 
-                "<input name='trxpeer' id='trxpeer' value='PEERIPV'>"
-                "</div><div>(255.255.255.255 = Local Broadcast IP will be used as Peer if empty)"
-                "</div><div><button>Submit</button></div></form></body></html>";
+                "</head>"
+                "<body>"
+                  "<form action='/set' method='get'>"
+                    "<div>"   // fields for network 1
+                      "<div>"
+                        "<label for='ssid1'>SSID of WiFi network 1?</label>"
+                        "<input name='ssid1' id='ssid1' value='SSIDV1'>"
+                      "</div>"
+                      "<div>"
+                        "<label for='pw1'>WiFi Password 1?</label>"
+                        "<input name='pw1' id='pw1'>"
+                      "</div>"
+                      "<div>"
+                        "<label for='trxpeer1'>WiFi TRX Peer IP/Host 1?</label>" 
+                        "<input name='trxpeer1' id='trxpeer1' value='PEERIPV1'>"
+                      "</div>"
+                    "</div>"
+                  
+                    "<div>"   // fields for network 2
+                      "<div>"
+                        "<label for='ssid2'>SSID of WiFi network 2?</label>"
+                        "<input name='ssid2' id='ssid2' value='SSIDV2'>"
+                      "</div>"
+                      "<div>"
+                        "<label for='pw2'>WiFi Password 2?</label>"
+                        "<input name='pw2' id='pw2'>"
+                      "</div>"
+                      "<div>"
+                        "<label for='trxpeer2'>WiFi TRX Peer IP/Host 2?</label>" 
+                        "<input name='trxpeer2' id='trxpeer2' value='PEERIPV2'>"
+                      "</div>"
+                    "</div>"
+                  
+                    "<div>"   // fields for network 3
+                      "<div>"
+                        "<label for='ssid3'>SSID of WiFi network 3?</label>"
+                        "<input name='ssid3' id='ssid3' value='SSIDV3'>"
+                      "</div>"
+                      "<div>"
+                        "<label for='pw3'>WiFi Password 3?</label>"
+                        "<input name='pw3' id='pw3'>"
+                      "</div>"
+                      "<div>"
+                        "<label for='trxpeer3'>WiFi TRX Peer IP/Host 3?</label>" 
+                        "<input name='trxpeer3' id='trxpeer3' value='PEERIPV3'>"
+                      "</div>"
+                    "</div>"
+                  
+                    "<div>"
+                      "(255.255.255.255 = Local Broadcast IP will be used as Peer if empty)"
+                    "</div>"
+                    "<div>"
+                      "<button>Submit</button>"
+                    "</div>"
+                  "</form>"
+                "</body>"
+              "</html>";
 
 
 /*
@@ -202,6 +249,63 @@ void internal::handleNotFound() {
   MorseWiFi::server.send(404, "text/plain", message);
 }
 
+void MorseWiFi::menuNetSelect() {
+  const int numNetworks = 3;
+  String names[numNetworks];
+  names[0] = "1: " + MorsePreferences::wlanSSID1;
+  names[1] = "2: " + MorsePreferences::wlanSSID2;
+  names[2] = "3: " + MorsePreferences::wlanSSID3;
+
+  MorseOutput::clearDisplay();
+  MorseOutput::printOnStatusLine( true, 0,  "Select Wifi");
+
+  int btnClicks;
+  int choice = 0;
+  int previousChoice = -1;
+  while (true) {
+    checkShutDown(false);  // possibly time-out: go to sleep
+    if(choice!=previousChoice) {
+      MorseOutput::clearThreeLines();
+      MorseOutput::printOnScroll(0, REGULAR, 0, names[choice] );
+      previousChoice = choice;
+    }
+    switch(checkEncoder()){
+      case -1:
+        if(choice == 0) {
+          choice = numNetworks;
+        }
+        choice--;
+        break;
+      case 1:
+        choice++;
+        if(choice >= numNetworks){
+          choice = 0;
+        }
+        break;
+    }
+    Buttons::modeButton.Update();
+    btnClicks = Buttons::modeButton.clicks;
+    if(btnClicks == 1)
+      break;
+    if(btnClicks == -1){
+      choice = -1;
+      break;
+    }
+  }
+
+  switch(choice) {
+    case 0: MorsePreferences::writeWifiInfo(MorsePreferences::wlanSSID1, MorsePreferences::wlanPassword1, MorsePreferences::wlanTRXPeer1);
+      break;
+    case 1: MorsePreferences::writeWifiInfo(MorsePreferences::wlanSSID2, MorsePreferences::wlanPassword2, MorsePreferences::wlanTRXPeer2);
+      break;
+    case 2: MorsePreferences::writeWifiInfo(MorsePreferences::wlanSSID3, MorsePreferences::wlanPassword3, MorsePreferences::wlanTRXPeer3);
+      break;
+    case -1: // double click pressed to exit menu
+      break;
+  }
+  
+}
+
 void MorseWiFi::menuExec(uint8_t command) {
   switch (command) {
     case  _wifi_mac:
@@ -266,8 +370,16 @@ void MorseWiFi::startAP() {
     String formular;
     formular.reserve(1024);
     formular = myForm;
-    formular.replace("SSIDV", MorsePreferences::wlanSSID);
-    formular.replace("PEERIPV", MorsePreferences::wlanTRXPeer); 
+
+    formular.replace("SSIDV1", MorsePreferences::wlanSSID1);
+    formular.replace("PEERIPV1", MorsePreferences::wlanTRXPeer1); 
+
+    formular.replace("SSIDV2", MorsePreferences::wlanSSID2);
+    formular.replace("PEERIPV2", MorsePreferences::wlanTRXPeer2); 
+
+    formular.replace("SSIDV3", MorsePreferences::wlanSSID3);
+    formular.replace("PEERIPV3", MorsePreferences::wlanTRXPeer3); 
+
     server.sendHeader("Connection", "close");
     server.send(200, "text/html", formular);
   });
@@ -275,7 +387,13 @@ void MorseWiFi::startAP() {
   server.on("/set", HTTP_GET, []() {
     server.sendHeader("Connection", "close");
     server.send(200, "text/html", "Wifi Info updated - now restarting Morserino-32...");
-    MorsePreferences::writeWifiInfo(String(server.arg("ssid")), String(server.arg("pw")), String(server.arg("trxpeer")));   
+
+    MorsePreferences::writeWifiInfoMultiple(
+      String(server.arg("ssid1")), String(server.arg("pw1")), String(server.arg("trxpeer1")),
+      String(server.arg("ssid2")), String(server.arg("pw2")), String(server.arg("trxpeer2")),
+      String(server.arg("ssid3")), String(server.arg("pw3")), String(server.arg("trxpeer3"))
+    );   
+
     //DEBUG("SSID: " + String(MorsePreferences::wlanSSID) + " Password: " + String(MorsePreferences::wlanPassword) + " Peer. " + String(MorsePreferences::wlanTRXPeer));
     ESP.restart();
   });
@@ -353,9 +471,8 @@ boolean MorseWiFi::wifiConnect() {                   // connect to local WLAN
   // Connect to WiFi network
   if (MorsePreferences::wlanSSID == "") 
       return internal::errorConnect(String("WiFi Not Conf"));
-    
-  WiFi.begin(MorsePreferences::wlanSSID.c_str(), MorsePreferences::wlanPassword.c_str());
 
+  WiFi.begin(MorsePreferences::wlanSSID.c_str(), MorsePreferences::wlanPassword.c_str());
   // Wait for connection
   long unsigned int wait = millis();
   while (WiFi.status() != WL_CONNECTED) {

--- a/Software/src/morse_3_v3.0/MorseWiFi.h
+++ b/Software/src/morse_3_v3.0/MorseWiFi.h
@@ -35,6 +35,7 @@ namespace MorseWiFi
     extern const char* serverIndex;
 
     void menuExec(uint8_t command);         // called from main menu, with argument from menu
+    void menuNetSelect();                   // display menu of wifi networks to select from
     void startAP();
     boolean wifiConnect();
     void uploadFile();

--- a/Software/src/morse_3_v3.0/morsedefs.h
+++ b/Software/src/morse_3_v3.0/morsedefs.h
@@ -229,7 +229,7 @@ enum menuNo
         _echo, _echoRand, _echoAbb, _echoWords, _echoCalls, _echoMixed, _echoPlayer,
         _koch, _kochSel, _kochLearn, _kochGen, _kochGenRand, _kochGenAbb, _kochGenWords,
         _kochGenMixed, _kochEcho, _kochEchoRand, _kochEchoAbb, _kochEchoWords, _kochEchoMixed,
-        _trx, _trxLora, _trxWifi, _trxIcw, _decode, _wifi, _wifi_mac, _wifi_config, _wifi_check, _wifi_upload, _wifi_update, _goToSleep 
+        _trx, _trxLora, _trxWifi, _trxIcw, _decode, _wifi, _wifi_mac, _wifi_config, _wifi_check, _wifi_upload, _wifi_update, _wifi_select, _goToSleep 
   };
 
 enum echoStates 


### PR DESCRIPTION
Support multiple wifi network configs as mentioned in #30 
Allow details for up to three network to be entered in the wifi config form
Add a new menu option to the wifi functions menu to allow selection of one of the networks