### PR TITLE
Fix documentation links

### DIFF
--- a/Documentation/Assembly Instructions/Detailed Assembly Instructions.md
+++ b/Documentation/Assembly Instructions/Detailed Assembly Instructions.md
@@ -13,7 +13,7 @@
 
 * **Soldering advice:** Do NOT use lead-free solder (I mentioned it before, didn't I). Use a high quality soldering iron, set to a reasonable temperature (I prefer them to be a bit on the high side - allows you to make the joints quickly, and some of the parts are biggish; if connected to ground, you need a lot of heat to make the joint, and staying there with the iron for many, many seconds waiting for the warm-up is a good way to ruin your PCB).
 
-* Check that all components are ready - identify them with the help of the packing list, and identify where they will go, with the help of the placement drawing. Please notify [mailto:info@morserino.info]() if any components are missing or defective, so that some replacement can be sent to you!
+* Check that all components are ready - identify them with the help of the packing list, and identify where they will go, with the help of the placement drawing. Please notify [mailto:info@morserino.info](mailto:info@morserino.info) if any components are missing or defective, so that some replacement can be sent to you!
 
 Please not that in edition 2 there are two trimmer potentiometers, one (500 or 1000 Ohm) with a small knob for fingernail adjustment!
 
@@ -133,7 +133,7 @@ Please not that in edition 2 there are two trimmer potentiometers, one (500 or 1
 
 ### Choice of LiPo battery for the Morserino-32
 
-For my Morserinos I use a small 600 mAh single-cell LiPo battery that is commonly used in RC devices like quadcopters etc. The brand I use is „Tattu“ and has the following specs (see [https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html]() or [https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html]()):
+For my Morserinos I use a small 600 mAh single-cell LiPo battery that is commonly used in RC devices like quadcopters etc. The brand I use is „Tattu“ and has the following specs (see https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html or https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html):
 
 **Tattu** 600mAh 3.7V 30C 1S1P Lipo Battery Pack with Molex Plug
 
@@ -152,7 +152,7 @@ It must be a single cell LiPo (nominally 3.7 V), and should have a Molex plug (b
 You can use larger batteries if you mount them under the PCB, on the bottom plate of the case. To give you more flexibility, the kit will contain 6mm and 12mm distance bolts for mounting to the bottom plate. This means you can use pretty large LiPos, as long as they are < 10 mm thick. If you use the 6mm and 12 mm stand-offs in combination, you could even use batteries that are up to 16 mm thick! You have to make sure that you mount the battery in such a way that it is impossible for any sharp metal spikes to scratch the surface of the battery - this could lead to fire or explosion!
 
 One option would be this type (in the picture the battery at the bottom):
-[https://www.amazon.de/gp/product/B01JJ6DA7A/]() or this type: [https://www.amazon.com/FPVERA-Battery-Connector-Charger-Quadcopter/dp/B089R8SGJR/]() even that one, for even more capacity: [https://www.gensace.de/gens-ace-3500mah-3-7v-tx-2s1p-lipo-battery-pack-with-jr-plug.html]() (but be aware that this one does not use a Molex plug - you would need to find a cable with a suitable plug to connect this to your Morserino-32).
+https://www.amazon.de/gp/product/B01JJ6DA7A/ or this type: https://www.amazon.com/FPVERA-Battery-Connector-Charger-Quadcopter/dp/B089R8SGJR/ even that one, for even more capacity: https://www.gensace.de/gens-ace-3500mah-3-7v-tx-2s1p-lipo-battery-pack-with-jr-plug.html (but be aware that this one does not use a Molex plug - you would need to find a cable with a suitable plug to connect this to your Morserino-32).
 ![Ass03](Images/batteries.jpg)
 
 *Two usable types of battery*

--- a/Documentation/Assembly Instructions/Detaillierte Aufbauanleitung.md
+++ b/Documentation/Assembly Instructions/Detaillierte Aufbauanleitung.md
@@ -12,7 +12,7 @@
 * Lege alle nötigen Werkzeuge bereit: einen Lötkolben mit feiner Spitze, einen dünnen Lötdraht (verwende kein bleifreies Lot, wenn du dir nicht das Leben schwer machen willst), gute Beleuchtung, möglicherweise eine Lupe, einen kleinen Drahtschneider und (zur Montage des Gehäuses) den kleinen 2mm Inbusschlüssel, der dem Bausatz beiliegt.
 * **Hinweise zum Löten:** KEIN bleifreies Lot verwenden (ich habe es schon erwähnt, nicht wahr?). Verwende einen hochwertigen Lötkolben, der auf eine vernünftige Temperatur eingestellt ist (ich bevorzuge es, ein wenig auf der hohen Seite zu sein - das ermöglicht es, die Verbindungen schnell herzustellen, und einige der Teile sind etwas groß, und wenn sie mit Masse verbunden sind, benötigen sie viel Hitze, um eine einwandfreie Lötstelle herzustellen. Dort viele Sekunden mit dem Lötkolben zu warten, bis das Lot endlich schmilzt, ist eine gute Möglichkeit, die Leiterplatte zu ruinieren.
 
-* Überprüfe, ob alle Komponenten bereit sind - identifiziere sie anhand der Packliste und ermittele anhand der Zeichnung, wohin sie gehören. Bitte informiere [mailto:info@morserino.info]() falls Bauteile fehlen oder defekt sein sollten, damit dir Ersatz geschickt werden kann!
+* Überprüfe, ob alle Komponenten bereit sind - identifiziere sie anhand der Packliste und ermittele anhand der Zeichnung, wohin sie gehören. Bitte informiere [mailto:info@morserino.info](mailto:info@morserino.info) falls Bauteile fehlen oder defekt sein sollten, damit dir Ersatz geschickt werden kann!
 
 Beachte dass in der zweiten Auflage 2 Trimmerpotentiometer enthalten sind, eines davon (500 oder 1000 Ohm) erkennt man an dem kleinen Knopf, mit dem es auch mit dem Fingernagel eingestellt werden kann.
 
@@ -137,7 +137,7 @@ Der rote Draht muss auf der Seite sein, wo am Heltec-Modul ein + aufgedruckt ist
 
 ### Auswahl eines geeigneten LiPo Akkus für den Morserino-32
 
-Für meine Morserinos verwende ich einen kleinen 600-mAh-LiPo-Einzelzellenakku, der üblicherweise in RC-Geräten wie Quadcoptern usw. verwendet wird. Die Marke, die ich verwende, ist „Tattu“ und hat die folgenden Spezifikationen (siehe [https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html]() or [https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html]()):
+Für meine Morserinos verwende ich einen kleinen 600-mAh-LiPo-Einzelzellenakku, der üblicherweise in RC-Geräten wie Quadcoptern usw. verwendet wird. Die Marke, die ich verwende, ist „Tattu“ und hat die folgenden Spezifikationen (siehe https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html or https://www.gensace.de/tattu-600mah-3-7v-30c-1s1p-lipo-battery-pack-with-molex-plug-1-pcs-pack.html):
 
 **Tattu** 600mAh 3.7V 30C 1S1P Lipo Akku mit Molex Stecker
 
@@ -156,7 +156,7 @@ Der Akku darf nur eine Zelle haben (Nominalspannung 3,7 V), und sollte mit einem
 Du kannst auch größere Akkus verwenden, die müssen dann unter der Platine auf der Bodenplatte des Gehäuses montiert werden. Damit man da etwas Flexibilität hat, liegen dem Bausatz Distanzstücke von 6mm und 12mm Länge bei, mit denen man die Bodenplatte befestigen kann. Mit den 12mm Distanzstücken dürfen die größeren Akkus bis zu 10 mm dick sein. Man könnte auch die 6mm und 12mm Abstandsbolzen in Kombination verwenden, da darf der Akku sogar bis zu 16 mm dick sein. Man muss in jedem Fall dafür sorgen, dass der Akku nicht durch vorstehende Spitzen auf der Paltinenunterseite beschädigt werden kann - dies könnte zu Feuer und Explosion des Akkus führen!
 
 Eine Option wäre dieser Typ (im Bild die Batterie unten):
-[https://www.amazon.de/gp/product/B01JJ6DA7A/]() oder dieser Typ: [https://www.amazon.com/FPVERA-Battery-Connector-Charger-Quadcopter/dp/B089R8SGJR/]() oder sogar dieser für noch mehr Kapazität: [https://www.gensace.de/gens-ace-3500mah-3-7v-tx-2s1p-lipo-battery-pack-with-jr-plug.html]() (aber beachte, dass dieser keinen Molex-Stecker verwendet - Man müsste ein Kabel mit einem geeigneten Stecker finden, um diesen an den Morserino-32 anzuschließen).
+https://www.amazon.de/gp/product/B01JJ6DA7A/ oder dieser Typ: https://www.amazon.com/FPVERA-Battery-Connector-Charger-Quadcopter/dp/B089R8SGJR/ oder sogar dieser für noch mehr Kapazität: https://www.gensace.de/gens-ace-3500mah-3-7v-tx-2s1p-lipo-battery-pack-with-jr-plug.html (aber beachte, dass dieser keinen Molex-Stecker verwendet - Man müsste ein Kabel mit einem geeigneten Stecker finden, um diesen an den Morserino-32 anzuschließen).
 
 ![Ass03](Images/batteries.jpg)
 


### PR DESCRIPTION
Mailto and battery links were broken in the documentation markdown files.