### PR TITLE
Update docs for latest update m32

### DIFF
--- a/Documentation/User Manual/Version 4.x/m32_user-Manual_v4.adoc
+++ b/Documentation/User Manual/Version 4.x/m32_user-Manual_v4.adoc
@@ -962,12 +962,12 @@ Now open a command box on your computer (in the search field in the lower left o
 
 Then enter the following command line:
 
-`update_m32 <COMx> 921600 <binaryfilename>`
+`update_m32 -p <COMx> -f <binaryfilename>`
 
 replacing <COMx> with your COM port name, and <binaryfilename> with the correct name of the Morserino binary file.
 In my case that was:
 
-`update_m32 COM3 921600 morse_3_v3.0.ino.wifi_lora_32_V2.bin`
+`update_m32 -p COM3 -f m32_v4.1.ino.wifi_lora_32_V2.bin`
 
 After a short while your Morserino should restart, showing the updated version number.
 

--- a/Documentation/User Manual/Version 4.x/m32_user-Manual_v4_de.adoc
+++ b/Documentation/User Manual/Version 4.x/m32_user-Manual_v4_de.adoc
@@ -959,11 +959,11 @@ Zuerst führe  "cd" (change directory) zu dem Verzeichnis aus, in das du das Pro
 
 Gib nun die folgende Befehlszeile ein:
 
-`update_m32 <COMx> 921600 <binaryfilename>`
+`update_m32 -p <COMx> -f <binaryfilename>`
 
 Ersetze  <COMx> durch den korrekten COM-Port-Namen und <binaryfilename> durch den korrekten Namen der Morserino-Binärdatei. In meinem Fall war dies:
 
-`update_m32 COM3 921600 morse_3_v3.0.ino.wifi_lora_32_V2.bin`
+`update_m32 -p COM3 -f m32_v4.1.ino.wifi_lora_32_V2.bin`
 
 Nach kurzer Zeit sollte der Morserino-32 neu starten und die aktualisierte Versionsnummer anzeigen.
 


### PR DESCRIPTION
This PR updates the manuals with

- The new url for update_m32 release versions
- Utilize the new command line arguments

I am unsure how to setup the toolchain to generate the pdf versions.