### PR TITLE
Add option to auto-select Koch lesson after symbol is keyed correctly multiple times in a row

### DIFF
--- a/Software/src/Version 4/MorseMenu.cpp
+++ b/Software/src/Version 4/MorseMenu.cpp
@@ -21,7 +21,7 @@ using namespace MorseMenu;
 //////// variables and constants for the modus menu
 
 
-const uint8_t menuN = 42;     // no of menu items +1
+const uint8_t menuN = 43;     // no of menu items +1
 
 const String menuText [menuN] = {
   "",
@@ -73,7 +73,8 @@ const String menuText [menuN] = {
     "Wifi Select", //40
   
   
-  "Go To Sleep" } ; // 41
+  "Go To Sleep",   // 41
+  "Auto Selection" } ; // 42  Koch
 
 enum navi {naviLevel, naviLeft, naviRight, naviUp, naviDown };
        
@@ -95,15 +96,15 @@ const uint8_t menuNav [menuN] [5] = {                   // { level, left, right,
   {1,_echoWords,_echoMixed,_echo,0},                    // 13 echo calls
   {1,_echoCalls,_echoPlayer,_echo,0},                   // 14 echo mixed
   {1,_echoMixed,_echoRand,_echo,0},                     // 15 echo player
-  {0,_echo,_trx,_dummy,_kochSel},                          // 16 koch
-  {1,_kochEcho,_kochLearn,_koch,0},                     // 17 koch select
+  {0,_echo,_trx,_dummy,_kochSel},                       // 16 koch
+  {1,_kochAutoSel,_kochLearn,_koch,0},                  // 17 koch select
   {1,_kochSel,_kochGen,_koch,0},                        // 18 koch learn new
   {1,_kochLearn,_kochEcho,_koch,_kochGenRand},          // 19 koch gen
   {2,_kochGenMixed,_kochGenAbb,_kochGen,0},             // 20 koch gen random
   {2,_kochGenRand,_kochGenWords,_kochGen,0},            // 21 koch gen abb
   {2,_kochGenAbb,_kochGenMixed,_kochGen,0},             // 22 koch gen words
   {2,_kochGenWords,_kochGenRand,_kochGen,0},            // 23 koch gen mixed
-  {1,_kochGen,_kochSel,_koch,_kochEchoRand},            // 24 koch echo
+  {1,_kochGen,_kochAutoSel,_koch,_kochEchoRand},        // 24 koch echo
   {2,_kochEchoMixed,_kochEchoAbb,_kochEcho,0},          // 25 koch echo random
   {2,_kochEchoRand,_kochEchoWords,_kochEcho,0},         // 26 koch echo abb
   {2,_kochEchoAbb,_kochEchoMixed,_kochEcho,0},          // 27 koch echo words
@@ -120,7 +121,8 @@ const uint8_t menuNav [menuN] [5] = {                   // { level, left, right,
   {1,_wifi_check,_wifi_update,_wifi,0},                 // 38 Upload File
   {1,_wifi_upload,_wifi_select,_wifi,0},                // 39 Update Firmware
   {1,_wifi_update,_wifi_mac,_wifi,0},                   // 40 Select network
-  {0,_wifi,_keyer,_dummy,0}                             // 41 goto sleep
+  {0,_wifi,_keyer,_dummy,0},                            // 41 goto sleep
+  {1,_kochEcho,_kochSel,_koch,0},                       // 42 koch Auto select check 16
 };
 
 //boolean quickStart;                                     // should we execute menu item immediately?
@@ -318,6 +320,12 @@ boolean MorseMenu::menuExec() {                                          // retu
       case  _kochSel: // Koch Select 
                 MorsePreferences::displayKeyerPreferencesMenu(MorsePreferences::posKochFilter);
                 MorsePreferences::adjustKeyerPreference(MorsePreferences::posKochFilter);
+                MorsePreferences::writePreferences("morserino");
+                return false;
+                break;
+      case  _kochAutoSel: // Koch Auto Select 
+                MorsePreferences::displayKeyerPreferencesMenu(MorsePreferences::posKochAutoSel);
+                MorsePreferences::adjustKeyerPreference(MorsePreferences::posKochAutoSel);
                 MorsePreferences::writePreferences("morserino");
                 return false;
                 break;

--- a/Software/src/Version 4/MorsePreferences.h
+++ b/Software/src/Version 4/MorsePreferences.h
@@ -111,6 +111,7 @@ namespace MorsePreferences
   extern uint32_t loraQRG;
   extern uint8_t snapShots;
   extern uint8_t boardVersion;
+  extern uint8_t okKeyingMaxCount;
   
   ////// end of variables stored in preferences
   
@@ -124,7 +125,7 @@ namespace MorsePreferences
                   posTrainerDisplay, posWordDoubler, posEchoDisplay, posEchoRepeats,  posEchoConf,
                   posKeyTrainerMode, posLoraTrainerMode, posGoertzelBandwidth, posSpeedAdapt,
                   posKochSeq, posKochFilter, posLatency, posRandomFile, posTimeOut, posQuickStart, posAutoStop,posMaxSequence, posLoraSyncW,   posSerialOut,
-                  posLoraBand, posLoraQRG, posSnapRecall, posSnapStore,  posVAdjust, posHwConf
+                  posLoraBand, posLoraQRG, posSnapRecall, posSnapStore,  posVAdjust, posHwConf, posKochAutoSel
                 };
   
   extern const String prefOption[];
@@ -239,6 +240,7 @@ namespace internal {
   void displaySnapRecall();
   void displaySnapStore();
   void displayHwConf();
+  void displayKochAutoSel();
 }
 
 class Koch {
@@ -249,6 +251,7 @@ class Koch {
     uint16_t numberOfAbbr;
     String kochCharSet;
     const String lcwoKochChars =      "kmuresnaptlwi.jz=foy,vg5/q92h38b?47c1d60x-K+ASNV@:";
+    uint8_t okKeyingCount;
     
     void createWords(uint8_t, uint8_t);
     void createAbbr(uint8_t, uint8_t);
@@ -265,7 +268,9 @@ class Koch {
     String getRandomAbbrev();
     void setKochChars(boolean);
     void setCustomChars(String chars);
-
+    void moveToNextKochLesson();
+    uint8_t getOkKeyingCount(void);
+    void setOkKeyingCount(uint8_t count);
 };
 
 extern Koch koch;

--- a/Software/src/Version 4/morsedefs.h
+++ b/Software/src/Version 4/morsedefs.h
@@ -192,7 +192,7 @@ enum menuNo
         _echo, _echoRand, _echoAbb, _echoWords, _echoCalls, _echoMixed, _echoPlayer,
         _koch, _kochSel, _kochLearn, _kochGen, _kochGenRand, _kochGenAbb, _kochGenWords,
         _kochGenMixed, _kochEcho, _kochEchoRand, _kochEchoAbb, _kochEchoWords, _kochEchoMixed,
-        _trx, _trxLora, _trxWifi, _trxIcw, _decode, _wifi, _wifi_mac, _wifi_config, _wifi_check, _wifi_upload, _wifi_update, _wifi_select, _goToSleep 
+        _trx, _trxLora, _trxWifi, _trxIcw, _decode, _wifi, _wifi_mac, _wifi_config, _wifi_check, _wifi_upload, _wifi_update, _wifi_select, _goToSleep, _kochAutoSel
   };
 
 enum echoStates 


### PR DESCRIPTION
Related to https://github.com/oe1wkl/Morserino-32/issues/45

- [x] Add new menu.
- [x] Add logic for auto-select new Koch lesson.
- [x] Bench test.