### PR TITLE
WiFi vs. HiFi and image source

### DIFF
--- a/Hardware/Technical_Overview.md
+++ b/Hardware/Technical_Overview.md
@@ -21,7 +21,7 @@ Two output pins of the ESP32 (Pins 22 asn 23) are being used to generate an audi
 
 For headphone use the speaker is replaced with a resistor (R11)  and the two speakers of the headphone in series, to bring the audio level down to a comfortable level.
 
-This arrangement creates low power audio, but certainly not in WiFi quality (the resulting audio is not a sinus tone, but has pretty strong 2nd, 3rd and 5th harmonics).
+This arrangement creates low power audio, but certainly not in HiFi quality (the resulting audio is not a sinus tone, but has pretty strong 2nd, 3rd and 5th harmonics).
 
 #### Audio Output (Line-Out)
 

--- a/Hardware/Technische_Beschreibung.md
+++ b/Hardware/Technische_Beschreibung.md
@@ -22,7 +22,7 @@ Zwei Ausgangspins des ESP32 (Pins 22 und 23) werden verwendet, um ein Audiosigna
 
 Bei Verwendung von Kopfhörern wird der Lautsprecher durch einen Widerstand (R11) und die beiden Lautsprecher des Kopfhörers in Reihe ersetzt, um das Audiosignal auf einen angenehmen Pegel zu bringen.
 
-Dieses Arrangement erzeugt Audio mit geringem Stromverbrauch, aber sicherlich nicht in WiFi-Qualität (das resultierende Audio ist kein Sinuston, sondern hat ziemlich starke 2., 3. und 5. Oberwellen).
+Dieses Arrangement erzeugt Audio mit geringem Stromverbrauch, aber sicherlich nicht in HiFi-Qualität (das resultierende Audio ist kein Sinuston, sondern hat ziemlich starke 2., 3. und 5. Oberwellen).
 
 ####Audioausgang (Line-Out)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Announcements via Email (through Mailchimp): http://eepurl.com/dwEVkz
 
 User Group (Email, through groups.io): https://groups.io/g/morserino
 
-![Morserino Image](https://raw.githubusercontent.com/oe1wkl/Morserino-32/master/Documentation/User%20Manual/Images/Morserino.jpg)
+![Morserino Image](https://raw.githubusercontent.com/oe1wkl/Morserino-32/master/Documentation/User%20Manual/Version%204.x/Morserino.jpg)
 
 ![DXZone logo](https://raw.githubusercontent.com/oe1wkl/Morserino-32/master/dxzone_180x85_rounded.gif)
 


### PR DESCRIPTION
I stumbled over something that probably is a typo (WiFi vs. HiFi) and fixed the markdown source. The .pdf  files are untouched, but need to be rebuilt.
And the image source in the repository's README.md resulted in a 404, so I tried to fix this too.
73
Christoph