### PR TITLE
fix: Unexpected restarts in 'Adaptive Random' mode

### DIFF
--- a/Software/src/Version 4/MorsePreferences.cpp
+++ b/Software/src/Version 4/MorsePreferences.cpp
@@ -1904,7 +1904,7 @@ void Koch::increaseWordProbability(String expected, String received)
   
   if (failedIndex > 0 && expected.charAt(failedIndex - 1) != expected.charAt(failedIndex))
     increaseCharProbability(expected.charAt(failedIndex - 1), 2);
-  if (failedIndex < expected.length() && expected.charAt(failedIndex + 1) != expected.charAt(failedIndex))
+  if ((failedIndex + 1) < expected.length() && expected.charAt(failedIndex + 1) != expected.charAt(failedIndex))
     increaseCharProbability(expected.charAt(failedIndex + 1), 2);
 }
 


### PR DESCRIPTION
increaseWordProbability() failed to check the failedIndex properly.