### PR TITLE
Reduce system resources used by adaptive random mode

### DIFF
--- a/Software/src/Version 4/MorsePreferences.cpp
+++ b/Software/src/Version 4/MorsePreferences.cpp
@@ -1906,7 +1906,7 @@ void Koch::increaseWordProbability(String& expected, String& received)
   
   if (failedIndex > 0 && expected.charAt(failedIndex - 1) != expected.charAt(failedIndex))
     increaseCharProbability(expected.charAt(failedIndex - 1), 2);
-  if ((failedIndex+1) < expected.length() && expected.charAt(failedIndex + 1) != expected.charAt(failedIndex))
+  if (failedIndex < expected.length() && expected.charAt(failedIndex + 1) != expected.charAt(failedIndex))
     increaseCharProbability(expected.charAt(failedIndex + 1), 2);
 }
 

--- a/Software/src/Version 4/MorsePreferences.cpp
+++ b/Software/src/Version 4/MorsePreferences.cpp
@@ -1764,6 +1764,7 @@ void Koch::setup() {                                                // create th
   }
 
   initSequence = getRandomCharSet();
+  initSequenceIndex = 0;
 }
 
 void Koch::setKochChars(boolean lcwo, boolean cwac) {             // define the demanded Koch character set
@@ -1857,15 +1858,15 @@ String Koch::getInitChar(int maxl)
 {
   String result;
 
-  if (maxl <= initSequence.length())
+  if (initSequenceIndex >= initSequence.length())
+    return result;
+  
+  result.reserve(maxl);
+
+  while (result.length() < maxl && initSequenceIndex < initSequence.length())
   {
-    result = initSequence.substring(0, maxl);
-    initSequence = initSequence.substring(maxl, initSequence.length());
-  }
-  else
-  {
-    result = initSequence;
-    initSequence = "";
+    result += initSequence.charAt(initSequenceIndex);
+    initSequenceIndex++;
   }
 
   return result;
@@ -1905,7 +1906,7 @@ void Koch::increaseWordProbability(String& expected, String& received)
   
   if (failedIndex > 0 && expected.charAt(failedIndex - 1) != expected.charAt(failedIndex))
     increaseCharProbability(expected.charAt(failedIndex - 1), 2);
-  if (failedIndex < expected.length() && expected.charAt(failedIndex + 1) != expected.charAt(failedIndex))
+  if ((failedIndex+1) < expected.length() && expected.charAt(failedIndex + 1) != expected.charAt(failedIndex))
     increaseCharProbability(expected.charAt(failedIndex + 1), 2);
 }
 

--- a/Software/src/Version 4/MorsePreferences.cpp
+++ b/Software/src/Version 4/MorsePreferences.cpp
@@ -1894,7 +1894,7 @@ String Koch::getRandomCharSet()
   return randomCharSet;
 }
 
-void Koch::increaseWordProbability(String expected, String received)
+void Koch::increaseWordProbability(String& expected, String& received)
 {
   int failedIndex = getFailedCharIndex(expected, received);
   if (failedIndex == -1)
@@ -1908,7 +1908,7 @@ void Koch::increaseWordProbability(String expected, String received)
     increaseCharProbability(expected.charAt(failedIndex + 1), 2);
 }
 
-int Koch::getFailedCharIndex(String expected, String received)
+int Koch::getFailedCharIndex(String& expected, String& received)
 {
   for (int i = 0; i < expected.length(); i++)
   {
@@ -1933,7 +1933,7 @@ void Koch::increaseCharProbability(char c, int16_t count)
     adaptiveProbabilities[increaseIndex] = charSet.length();
 }
 
-void Koch::decreaseWordProbability(String word)
+void Koch::decreaseWordProbability(String& word)
 {
   for (int i = 0; i < word.length(); i++)
   {

--- a/Software/src/Version 4/MorsePreferences.cpp
+++ b/Software/src/Version 4/MorsePreferences.cpp
@@ -1750,7 +1750,7 @@ void Koch::setup() {                                                // create th
   createAbbr(MorsePreferences::abbrevLength, MorsePreferences::useCustomCharSet ? kochCharsLength+1 : MorsePreferences::kochFilter);
 
   String charSet = getCharSet();
-  int16_t probability = 0;
+  uint8_t probability = 0;
   for (int i = 0; i < kochCharsLength; i++)
   {
     if (i >= charSet.length())
@@ -1924,7 +1924,7 @@ int Koch::getFailedCharIndex(String& expected, String& received)
   return -1;
 }
 
-void Koch::increaseCharProbability(char c, int16_t count)
+void Koch::increaseCharProbability(char c, uint8_t count)
 {
   String charSet = getCharSet();
   int increaseIndex = charSet.indexOf(c);

--- a/Software/src/Version 4/MorsePreferences.cpp
+++ b/Software/src/Version 4/MorsePreferences.cpp
@@ -1881,16 +1881,17 @@ String Koch::getCharSet()
 
 String Koch::getRandomCharSet()
 {
-  String sortedCharSet = getCharSet();
-  String randomCharSet = "";
+  String charSet = getCharSet();
+  String randomCharSet;
+  randomCharSet.reserve(charSet.length());
 
-  while (sortedCharSet.length() > 0)
+  for (int i = 0; i < charSet.length(); i++)
   {
-    int index = random(sortedCharSet.length());
-    randomCharSet += sortedCharSet.charAt(index);
-    sortedCharSet = sortedCharSet.substring(0, index) + sortedCharSet.substring(index + 1, sortedCharSet.length());
+    int charIndex = random(charSet.length() - i);
+    randomCharSet += charSet.charAt(charIndex);
+    charSet.setCharAt(charIndex, charSet.charAt(charSet.length() - i - 1));
   }
-  
+
   return randomCharSet;
 }
 

--- a/Software/src/Version 4/MorsePreferences.h
+++ b/Software/src/Version 4/MorsePreferences.h
@@ -246,6 +246,7 @@ class Koch {
 
     int16_t adaptiveProbabilities[kochCharsLength];
     String initSequence;
+    uint8_t initSequenceIndex;
 
   public:
     const String morserinoKochChars = "mkrsuaptlowi.njef0yv,g5/q9zh38b?427c1d6x-=K+SNAE@:";

--- a/Software/src/Version 4/MorsePreferences.h
+++ b/Software/src/Version 4/MorsePreferences.h
@@ -244,7 +244,7 @@ class Koch {
     void createAbbr(uint8_t, uint8_t);
     uint8_t wordIsKoch(String);
 
-    int16_t adaptiveProbabilities[kochCharsLength];
+    uint8_t adaptiveProbabilities[kochCharsLength];
     String initSequence;
     uint8_t initSequenceIndex;
 
@@ -266,7 +266,7 @@ class Koch {
     int16_t getProbabilitySum();
     void increaseWordProbability(String& expected, String& received);
     int getFailedCharIndex(String& expected, String& received);
-    void increaseCharProbability(char c, int16_t count);
+    void increaseCharProbability(char c, uint8_t count);
     void decreaseWordProbability(String& word);
     void decreaseCharProbability(char c);
 };

--- a/Software/src/Version 4/MorsePreferences.h
+++ b/Software/src/Version 4/MorsePreferences.h
@@ -263,10 +263,10 @@ class Koch {
     void setKochChars(boolean, boolean);
     void setCustomChars(String chars);
     int16_t getProbabilitySum();
-    void increaseWordProbability(String expected, String received);
-    int getFailedCharIndex(String expected, String received);
+    void increaseWordProbability(String& expected, String& received);
+    int getFailedCharIndex(String& expected, String& received);
     void increaseCharProbability(char c, int16_t count);
-    void decreaseWordProbability(String word);
+    void decreaseWordProbability(String& word);
     void decreaseCharProbability(char c);
 };
 


### PR DESCRIPTION
This pull request reduces system resources used by adaptive random mode.

- passing strings by ref where possible
- significantly reducing the number heap-allocations in getInitChar() and getRandomCharSet() to prevent possible heap fragmentation
- use uint8_t instead of uint16_t for the character probability

Ref. https://cpp4arduino.com/2018/11/21/eight-tips-to-use-the-string-class-efficiently.html
Tip 3, 5 and 6