### PR TITLE
Improve accuracy of battery voltage measurement on v4 boards

### DIFF
--- a/Software/src/Version 4/m32_v4.ino
+++ b/Software/src/Version 4/m32_v4.ino
@@ -379,17 +379,14 @@ void setup()
   MorsePreferences::readPreferences("morserino");
   koch.setup(); 
 
- 
-   // enable Vext
   pinMode(Vext, OUTPUT);
-  digitalWrite(Vext,LOW);
-  
-  //DEBUG("Vext ON");
- 
 
   // measure battery voltage, then set pinMode (important for board 4, as the same pin is used for battery measurement
   volt = batteryVoltage();
   pinMode(modeButtonPin, INPUT);
+
+  // enable Vext
+  digitalWrite(Vext,LOW);
 
  //DEBUG("Volt: " + String(volt));
 
@@ -1846,6 +1843,14 @@ String cleanUpProSigns( String &input ) {
 //// measure battery voltage in mV
 
 int16_t batteryVoltage() {      /// measure battery voltage and return result in milliVolts
+
+      // board version 3 requires Vext being on for reading the battery voltage
+      if (MorsePreferences::boardVersion == 3)
+         digitalWrite(Vext,LOW);
+      // board version 4 requires Vext being off for reading the battery voltage
+      else if (MorsePreferences::boardVersion == 4)
+         digitalWrite(Vext,HIGH);
+
       delay(64);
       double v= 0; int counts = 4;
       for (int i=0; i<counts   ; ++i) {
@@ -1855,7 +1860,7 @@ int16_t batteryVoltage() {      /// measure battery voltage and return result in
       }
       v /= counts;
       if (MorsePreferences::boardVersion == 4)      // adjust measurement for board version 4
-        v *= 1.7;
+        v *= 1.1;
       voltage_raw = v;
       v *= (MorsePreferences::vAdjust * 12.9);      // adjust measurement and convert to millivolts
       return (int16_t) v;                                                                                       


### PR DESCRIPTION
I found that the battery voltage measurement on my v4 board is very unreliable. Even when using the user calibration, any measurements done at different battery voltages are highly inaccurate. This can be massively improved by disabling Vext while doing the voltage measurement. A detailed explanation can be found in the commit message which is copied below.

---

When Vext is on (i.e., its control pin is LOW), the voltage divider on board version 4 for measuring the battery voltage is quite complex:

```
vbat - 220k \     / 100k \        <-- Heltec onboard divider (R10/R11)
              adc          gnd
 v3  - 165k /     \ 100k /        <-- resistance in rotary encoder and R7
```

The resistance in the rotary encoder is not documented and for this example was just measured on a random board. While this complexity could be handled in software, Q3 on the Heltec board is also involved and seems to add some non-linearity. Overall, obtaining a reliable voltage measurement in this configuration is not possible.

Disabling Vext (i.e., setting its control pin to HIGH), simplifies the voltage divider a lot:

```
vbat - 220k - adc - 100k - gnd    <-- R10 on Heltec board and R7
```

In particular, Q3 on the Heltec board is taken out of the equation, giving us a more linear voltage curve.

Following is a comparison of actual and measured voltages. In both cases, the user calibration has been used to calibrate the readings at 3.7V.

```
Before this change:
-------------------
Actual	Read
3.003	3.225
3.103	3.304
3.202	3.390
3.302	3.480
3.401	3.557
3.501	3.635
3.601	3.671
3.700	3.697
3.800	3.714
3.900	3.726
4.000	3.741
4.099	3.756
4.199	3.773

After this change:
------------------
Actual	Read
3.003	2.896
3.103	3.007
3.202	3.136
3.302	3.248
3.402	3.354
3.501	3.498
3.601	3.597
3.700	3.702
3.801	3.801
3.900	3.894
4.000	3.986
4.100	4.091
4.199	4.190
```

Resources:
---------
* Schematic of v3 board:
  https://raw.githubusercontent.com/oe1wkl/Morserino-32/master/Hardware/1st_edition/Morserino-32_board_v3_schematics.pdf
* Schematic of Heltec board used on v3 board:
  https://resource.heltec.cn/download/WiFi_LoRa_32/V2/WiFi_LoRa_32_V2(433%2C470-510).PDF
* Schematic of v4 board:
  https://raw.githubusercontent.com/oe1wkl/Morserino-32/master/Hardware/2nd_edition/schematics.pdf
* Schematic of Heltec board used on v4 board:
  https://resource.heltec.cn/download/WiFi_LoRa_32/V2.1/WiFi_LoRa_32_V2.1(433%2C470-510).PDF
* Attempt of simulating the voltage divider with Vext on:
  https://tinyurl.com/2ezyeo9u