### PR TITLE
Allowing to set spaces as used in CWops beginner course.

### DIFF
--- a/Software/src/Version 5/MorsePreferences.cpp
+++ b/Software/src/Version 5/MorsePreferences.cpp
@@ -120,14 +120,14 @@ parameter MorsePreferences::pliste[] = {
     {"No Tone Shift", "Up 1 Half", "Down 1 Half"}
   },
   {
-    7, 6, 45, 1,                                                // Generator: normal interword spacing in lengths of dit,          6 - 45 ; default = norm = 7
+    7, 6, 105, 1,                                                // Generator: normal interword spacing in lengths of dit,          6 - 45 ; default = norm = 7
     "InterWord Spc",
     "The time (in dits) that is inserted between generated words",
     false,
     {}
   },
   {
-    3, 3, 24, 1,                                                  // for generators: intercharacter space, in dit dit lengths
+    3, 3, 45, 1,                                                  // for generators: intercharacter space, in dit dit lengths
     "Interchar Spc",
     "Space between generated characters, in dits",
     false,

--- a/Software/src/Version 5/MorsePreferences.cpp
+++ b/Software/src/Version 5/MorsePreferences.cpp
@@ -120,7 +120,7 @@ parameter MorsePreferences::pliste[] = {
     {"No Tone Shift", "Up 1 Half", "Down 1 Half"}
   },
   {
-    7, 6, 105, 1,                                                // Generator: normal interword spacing in lengths of dit,          6 - 45 ; default = norm = 7
+    7, 6, 105, 1,                                                // Generator: normal interword spacing in lengths of dit,          6 - 105 ; default = norm = 7
     "InterWord Spc",
     "The time (in dits) that is inserted between generated words",
     false,


### PR DESCRIPTION
Allowing to set inter-word and inter-character spaces as used in CWops beginner course. This would be a minimal solution for #78.