### PR TITLE
Feature pindefines

### DIFF
--- a/Software/src/Version 6/ClickButton.cpp
+++ b/Software/src/Version 6/ClickButton.cpp
@@ -50,7 +50,11 @@ ClickButton::ClickButton(uint8_t buttonPin)
   debounceTime   = 20;            // Debounce timer in ms
   multiclickTime = 250;           // Time limit for multi clicks
   longClickTime  = 1000;          // time until long clicks register
+#ifdef INTERNAL_PULLUP
+  pinMode(pin, INPUT_PULLUP);
+#else
   pinMode(pin, INPUT);
+#endif
 }
 
 /*

--- a/Software/src/Version 6/MorsePreferences.cpp
+++ b/Software/src/Version 6/MorsePreferences.cpp
@@ -780,8 +780,12 @@ boolean MorsePreferences::adjustKeyerPreference(prefPos pos) {        /// rotati
             jsonActivate(ACT_EXIT); 
             goToMenu = false;
             return true;
-        } 
+        }
+#ifdef INTERNAL_PULLUP
+        pinMode(modeButtonPin, INPUT_PULLUP);
+#else
         pinMode(modeButtonPin, INPUT);
+#endif
 
         Buttons::modeButton.Update();
         switch (Buttons::modeButton.clicks) {

--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -415,17 +415,35 @@ void setup()
     rightPin = 32;
   } else {        // must be board version 4
     batteryPin = 37;
+#ifndef INTERNAL_PULLUP
     Buttons::modeButton.activeHigh = HIGH;      // in contrast to board v.3, in v4. the active state is HIGH not LOW
+#endif
     leftPin = 32;
     rightPin = 33;
   }
 
+#ifdef PIN_PADDLE_LEFT
+  leftPin = PIN_PADDLE_LEFT;
+#endif
+#ifdef PIN_PADDLE_RIGHT
+  rightPin = PIN_PADDLE_RIGHT;
+#endif
 
+#ifdef PIN_BATTERY
+  batteryPin = PIN_BATTERY;
+#endif
+
+#ifdef Heltec_Vext
   pinMode(Vext, OUTPUT);
   //enable Vext
   digitalWrite(Vext,LOW);
-  
-  
+#endif
+
+#ifdef PIN_VEXT
+  pinMode(VEXT, OUTPUT);
+  digitalWrite(VEXT, LOW);
+#endif
+
 
   // read preferences from non-volatile storage
   // if version cannot be read, we have a new ESP32 and need to write the preferences first
@@ -435,8 +453,11 @@ void setup()
 
   // measure battery voltage, then set pinMode (important for board 4, as the same pin is used for battery measurement
   volt = batteryVoltage();
+#ifdef INTERNAL_PULLUP
+  pinMode(modeButtonPin, INPUT_PULLUP);
+#else
   pinMode(modeButtonPin, INPUT);
-
+#endif
 
 
  //DEBUG("Volt: " + String(volt));
@@ -445,9 +466,13 @@ void setup()
   pinMode(PinCLK,INPUT_PULLUP);
   pinMode(PinDT,INPUT_PULLUP);  
   pinMode(keyerPin, OUTPUT);        // we can use the built-in LED to show when the transmitter is being keyed
-  pinMode(leftPin, INPUT);          // external keyer left paddle
-  pinMode(rightPin, INPUT);         // external keyer right paddle
-
+#ifdef INTERNAL_PULLUP
+  pinMode(leftPin, INPUT_PULLUP);          // external keyer left paddle
+  pinMode(rightPin, INPUT_PULLUP);         // external keyer right paddle
+#else
+  pinMode(leftPin, INPUT);
+  pinMode(rightPin, INPUT);
+#endif
   
   analogSetAttenuation(ADC_0db);
 
@@ -465,7 +490,11 @@ void setup()
 /// set up for encoder button
 //  pinMode(modeButtonPin, INPUT);
   pinMode(volButtonPin, INPUT_PULLUP);               // external pullup for all GPIOS > 32 with ESP32-LORA
+#ifdef INTERNAL_PULLUP
+  pinMode(modeButtonPin, INPUT_PULLUP);
+#else
   pinMode(modeButtonPin, INPUT);
+#endif
                                                      // wake up also works without external pullup! Interesting!
   
   // Setup button timers (all in milliseconds / ms)

--- a/Software/src/Version 6/morsedefs.h
+++ b/Software/src/Version 6/morsedefs.h
@@ -149,13 +149,13 @@ const int HF_Pin = 22;
 
 
 /// where are the touch paddles?
-#ifdef PIN_PADDLE_LEFT
-const int LEFT = PIN_PADDLE_LEFT;
+#ifdef PIN_TOUCH_LEFT
+const int LEFT = PIN_TOUCH_LEFT;
 #else
 const int LEFT = T2;        // = Pin 2
 #endif
-#ifdef PIN_PADDLE_RIGHT
-const int RIGHT = PIN_PADDLE_RIGHT;
+#ifdef PIN_TOUCH_RIGHT
+const int RIGHT = PIN_TOUCH_RIGHT;
 #else
 const int RIGHT = T5;       // = Pin 12
 #endif

--- a/Software/src/Version 6/morsedefs.h
+++ b/Software/src/Version 6/morsedefs.h
@@ -104,38 +104,84 @@ namespace Buttons
 
 
 /// where is the encoder?
-const int PinCLK=38;                   // Used for generating interrupts using CLK signal - needs external pullup resisitor! 
-const int PinDT=39;                    // Used for reading DT signal  - needs external pullup resisitor! 
+#ifdef PIN_ROT_CLK
+const int PinCLK=PIN_ROT_CLK;          // Used for generating interrupts using CLK signal - needs external pullup resisitor!
+#else
+const int PinCLK=38;
+#endif
+
+#ifdef PIN_ROT_DT
+const int PinDT=PIN_ROT_DT;            // Used for reading DT signal  - needs external pullup resisitor! 
+#else
+const int PinDT=39;
+#endif
 
 /// encoder switch (BLACK knob)
+#ifdef PIN_ROT_CLK
+const int modeButtonPin = PIN_ROT_BTN;
+#else
 const int modeButtonPin = 37;
+#endif
 
 /// 2nd switch button - toggles between Speed control and Volume control (RED button)
+#ifdef PIN_VOL_BTN
+const int volButtonPin = PIN_VOL_BTN;
+#else
 const int volButtonPin = 0;
+#endif
 
 
 //// with the following we define which pins are used as output for the two pwm channels
 //// HF output (with varying duticycle and fixed frequency) and LF output (with varying frequency and fixed dutycycle of 50%)
 /// are being added with a 2-transistor AND gate to create a tone frequency with variable frequency and volume
 
-const int LF_Pin = 23;    // for the lower (= NF) frequency generation
-const int HF_Pin = 22;    // for the HF PWM generation
+#ifdef PIN_LF
+const int LF_Pin = PIN_LF;    // for the lower (= NF) frequency generation
+#else
+const int LF_Pin = 23;
+#endif
+
+#ifdef PIN_HF
+const int HF_Pin = PIN_HF;    // for the HF PWM generation
+#else
+const int HF_Pin = 22;
+#endif
 
 
 /// where are the touch paddles?
+#ifdef PIN_PADDLE_LEFT
+const int LEFT = PIN_PADDLE_LEFT;
+#else
 const int LEFT = T2;        // = Pin 2
+#endif
+#ifdef PIN_PADDLE_RIGHT
+const int RIGHT = PIN_PADDLE_RIGHT;
+#else
 const int RIGHT = T5;       // = Pin 12
+#endif
 
 // Tx keyer 
-const int keyerPin = 25;        // this keys the transmitter / through a MOSFET Optocoupler - at the same time lights up the LED
+#ifdef PIN_KEYER
+const int keyerPin = PIN_KEYER; // this keys the transmitter / through a MOSFET Optocoupler - at the same time lights up the LED
+#else
+const int keyerPin = 25;
+#endif
 
 
 // audio in
-const int audioInPin = 36;      // audio in for Morse decoder // 
+#ifdef PIN_AUDIO_IN
+const int audioInPin = PIN_AUDIO_IN;      // audio in for Morse decoder // 
+#else
+const int audioInPin = 36;
+#endif
 
 
 // NF Line-out (for iCW etc.)
+#ifdef PIN_AUDIO_OUT
+const int lineOutPin = PIN_AUDIO_OUT; // for NF line out
+#else
 const int lineOutPin = 17; // for NF line out
+#endif
 
 
 // SENS_FACTOR is used for auto-calibrating sensitivity of touch paddles (somewhere between 2.0 and 2.5)


### PR DESCRIPTION
This PR allows overriding the pin definitions and `pinMode` (INPUT vs INPUT_PULLUP) via define (e.g. passed via pio `build_flags`).