### PR TITLE
support 32bit touchRead() on ESP32-S2 and S3

### DIFF
--- a/Software/src/Version 6/MorsePreferences.cpp
+++ b/Software/src/Version 6/MorsePreferences.cpp
@@ -367,8 +367,8 @@ uint8_t MorsePreferences::loraPower = 14;                   // default 14 dBm = 
 
   uint32_t MorsePreferences::fileWordPointer = 0;             // remember how far we have read the file in player mode / reset when loading new file
   //uint8_t MorsePreferences::promptPause = 2;                  // in echoTrainer mode, length of pause before we send next word; multiplied by interWordSpace
-  uint8_t MorsePreferences::tLeft = 20;                       // threshold for left paddle
-  uint8_t MorsePreferences::tRight = 20;                      // threshold for right paddle
+  touch_value_t MorsePreferences::tLeft = 20;                       // threshold for left paddle
+  touch_value_t MorsePreferences::tRight = 20;                      // threshold for right paddle
 
   uint8_t MorsePreferences::vAdjust = 180;                    // correction value: 155 - 250
 

--- a/Software/src/Version 6/MorsePreferences.h
+++ b/Software/src/Version 6/MorsePreferences.h
@@ -92,8 +92,8 @@ namespace MorsePreferences
 
   extern uint32_t fileWordPointer;
   extern uint8_t promptPause;
-  extern uint8_t tLeft;
-  extern uint8_t tRight;
+  extern touch_value_t tLeft;
+  extern touch_value_t tRight;
   extern uint8_t vAdjust;
   extern uint8_t loraBand;
  #define QRG433 434.15E6


### PR DESCRIPTION
This feature patch uses `touch_value_t` instead of uint and detects the size of the touchRead return values to adjust for differences in ESP32 vs ESP32-S2&S3. A fixed threshold works fine on S2/S3 due to the much higher value ranges. Touch functionality can be disabled by defining `TOUCHPADDLES_DISABLED`.