### PR TITLE
Feature radiolib

### DIFF
--- a/Software/src/Version 6/MorseDecoder.cpp
+++ b/Software/src/Version 6/MorseDecoder.cpp
@@ -25,7 +25,7 @@ extern int leftPin;
 Decoder::Decoder(boolean key) {
    fromKey = key;                // this instance should be audio or key?
    setup();
-   MorseTable myTable;
+   M32MorseTable myTable;
 }
 
 void Decoder::setup() {
@@ -228,26 +228,26 @@ uint8_t Decoder::getWpm() {
 }
 
 
-//////// methods for class MorseTable /////////
+//////// methods for class M32MorseTable /////////
 
-MorseTable::MorseTable()
+M32MorseTable::M32MorseTable()
 {
   treeptr = 0;
 }
 
-void MorseTable::recordDit() {      /// walk down the dit branch
+void M32MorseTable::recordDit() {      /// walk down the dit branch
   treeptr = CWtree[treeptr].dit;
 }
 
-void MorseTable::recordDah() {      /// walk down the dah branch
+void M32MorseTable::recordDah() {      /// walk down the dah branch
   treeptr = CWtree[treeptr].dah;
 }
 
-void MorseTable::resetTable() {     /// go back to the root
+void M32MorseTable::resetTable() {     /// go back to the root
   treeptr = 0;
 }
 
-String MorseTable::retrieveSymbol() { /// deliver the character, and go backk to the root
+String M32MorseTable::retrieveSymbol() { /// deliver the character, and go backk to the root
   String symbol;
   symbol.reserve(6);
   if (treeptr == 0 )  

--- a/Software/src/Version 6/MorseDecoder.h
+++ b/Software/src/Version 6/MorseDecoder.h
@@ -110,16 +110,16 @@ const struct linklist CWtree[69]  = {
   {"<bk>", 63, 63}      // 68 <bk>
 };
 
-//// we define two classes: MorseTable (a pointer to the linked list defined above, and mthods to manipulate the pointer)
+//// we define two classes: M32MorseTable (a pointer to the linked list defined above, and mthods to manipulate the pointer)
 ////                   and  Decoder (which decodes signals from a key or from audio - derived from a Goertzel filter) 
 
-class MorseTable {
+class M32MorseTable {
 
 private:
   byte treeptr;
 
 public:
-  MorseTable();
+  M32MorseTable();
   void recordDit();
   void recordDah();  
   void resetTable();  
@@ -155,7 +155,7 @@ private:
   void recalculateDah(unsigned long );
 
   //byte treeptr;                          // pointer used to navigate within the linked list representing the dichotomic tree
-  MorseTable myTable;
+  M32MorseTable myTable;
   
 public:
   Decoder(boolean);

--- a/Software/src/Version 6/MorseMenu.cpp
+++ b/Software/src/Version 6/MorseMenu.cpp
@@ -16,6 +16,11 @@
 #include "MorseOutput.h"
 #include "MorseDecoder.h"
 
+#ifdef LORA_RADIOLIB
+#include <RadioLib.h>
+extern RADIO radio;
+#endif
+
 using namespace MorseMenu;
 
 //////// variables and constants for the modus menu
@@ -135,8 +140,10 @@ void MorseMenu::menu_() {
    uint8_t disp = 0;
    int t, command;
    m32state = menu_loop;
-      
-    LoRa.idle();
+
+#ifdef LORA_RADIOLIB
+    radio.standby();
+#endif
     WiFi.disconnect(true, false);
     genIsActive = false;
     cleanStartSettings();
@@ -430,7 +437,9 @@ boolean MorseMenu::menuExec() {                                          // retu
                 showStartDisplay("", "Start LoRa Trx", "", 500);
                 clearPaddleLatches();
                 clearText = "";
-                LoRa.receive();
+#ifdef LORA_RADIOLIB
+                radio.startReceive();
+#endif
                 executeNow = false;
                 return true;
                 break;

--- a/Software/src/Version 6/MorsePreferences.cpp
+++ b/Software/src/Version 6/MorsePreferences.cpp
@@ -20,6 +20,11 @@
 #include "ClickButton.h"   // button control library
 #include "goertzel.h"
 
+#ifdef LORA_RADIOLIB
+#include <RadioLib.h>
+extern RADIO radio;
+#endif
+
 using namespace MorsePreferences;
 
 Preferences pref;               // use the Preferences library for storing and retrieving objects
@@ -1158,7 +1163,9 @@ void MorsePreferences::writePreferences(String repository) {
             switch (i) {                                                              // in certain cases we need to do something
               case posLoraChannel:
                     if (morserino)
-                      LoRa.setSyncWord(MorsePreferences::pliste[posLoraChannel].value == 0 ? 0x27 : 0x66);
+#ifdef LORA_RADIOLIB
+                      radio.setSyncWord(MorsePreferences::pliste[posLoraChannel].value == 0 ? 0x27 : 0x66);
+#endif
                     break;
               case posGoertzelBandwidth:
                     if (morserino)

--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -60,7 +60,7 @@ ClickButton Buttons::volButton(volButtonPin);               // external pullup f
 
 Decoder keyDecoder(USE_KEY);
 Decoder audioDecoder(USE_AUDIO);
-MorseTable keyerTable;
+M32MorseTable keyerTable;
 Koch koch;
 
 // things for reading the encoder

--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -41,6 +41,24 @@
 #include "goertzel.h"         // Goertzel filter
 #include "MorseDecoder.h"     // Decoder Engine
 
+#ifdef LORA_RADIOLIB
+#include <RadioLib.h>
+#ifdef RADIO_SX1262
+#pragma message ("Compiling with Radiolib SX1262")
+RADIO radio = new Module(LoRa_nss, LoRa_dio1, LoRa_nrst, LoRa_busy); // SX1262
+#else
+#pragma message ("Compiling with Radiolib SX1278")
+RADIO radio = new Module(LoRa_nss, LoRa_dio0, LoRa_nrst, LoRa_dio1); // SX1278
+#endif
+#endif
+
+volatile bool loraReceived = false;
+#if defined(ESP8266) || defined(ESP32)
+ICACHE_RAM_ATTR
+#endif
+void packetReceived() {
+  loraReceived = true;
+}
 
 // define the buttons for the clickbutton library, & other classes that we need
 
@@ -476,8 +494,9 @@ void setup()
   
   analogSetAttenuation(ADC_0db);
 
- // init display, LoRa
-  Heltec.begin(true /*DisplayEnable Enable*/, true /*LoRa Enable*/, true /*Serial Enable*/, true /*LoRa use PABOOST*/, BAND /*LoRa RF working band*/);
+ // init display (LoRa Enable is false here as this is handled via radiolib)
+  Heltec.begin(true /*DisplayEnable Enable*/, false /*LoRa Enable*/, true /*Serial Enable*/, true /*LoRa use PABOOST*/, BAND /*LoRa RF working band*/);
+
   Heltec.display -> setBrightness(MorsePreferences::oledBrightness);
   MorseOutput::clearDisplay();
   MorseOutput::soundSetup();
@@ -540,16 +559,19 @@ void setup()
 
 ////////////  Setup for LoRa
 
-  LoRa.setFrequency(MorsePreferences::loraQRG+0000);                       /// default = 434.150 MHz - Region 1 ISM Band, can be changed by system setup
-  LoRa.setSpreadingFactor(7);                         /// default
-  LoRa.setSignalBandwidth(250E3);                     /// 250 kHz
-  //DEBUG("@499: loraPower: " + String(MorsePreferences::loraPower));
-  LoRa.setTxPower(MorsePreferences::loraPower, PA_OUTPUT_PA_BOOST_PIN);       // default 14 (dBm) = 25 mW
-  LoRa.noCrc();                                       /// we use error correction
-  LoRa.setSyncWord(MorsePreferences::pliste[posLoraChannel].value == 0 ? 0x27 : 0x66);                      /// the default would be 0x27 /// new value for 
-  
-  // register the receive callback
-  LoRa.onReceive(onLoraReceive);
+#ifdef LORA_RADIOLIB
+  SPI.begin(LoRa_SCK, LoRa_MISO, LoRa_MOSI, LoRa_nss);
+  Serial.print(F("[SX12xx] Initializing ... "));
+  int state = radio.begin();
+  if (state != RADIOLIB_ERR_NONE) Serial.println("ERROR: radiolib begin()");
+  radio.setFrequency(MorsePreferences::loraQRG/1000000.0);
+  radio.setBandwidth(250.0);
+  radio.setSpreadingFactor(7);
+  radio.setSyncWord(MorsePreferences::pliste[posLoraChannel].value == 0 ? 0x27 : 0x66);
+  radio.setOutputPower(MorsePreferences::loraPower);
+  radio.setCRC(false);
+  radio.setPacketReceivedAction(packetReceived);
+#endif
   /// initialise the serial number
   cwTxSerial = random(64);
 
@@ -908,6 +930,12 @@ void loop() {
           }
     } // encoder 
     checkShutDown(false);         // check for time out
+#ifdef LORA_RADIOLIB
+    if(loraReceived) {
+      loraReceived=false;
+      onLoraReceive();
+    }
+#endif
     
 }     /////////////////////// end of loop() /////////
 
@@ -2162,8 +2190,9 @@ void shutMeDown() {
     jsonError("M32 SLEEP SHUTDOWN BY USER");
   
   esp_sleep_enable_ext0_wakeup(GPIO_NUM_0, 0); //1 = High, 0 = Low
-
-  LoRa.sleep();                   //LORA sleep
+#ifdef LORA_RADIOLIB
+  radio.sleep();
+#endif
   WiFi.disconnect(true, false);
   delay(100);
   digitalWrite(Vext,HIGH);
@@ -2234,12 +2263,15 @@ void cwForTx (int element) {
 
 
 void sendWithLora() {           // hand this string over as payload to the LoRA transceiver
-  // send packet
-  LoRa.beginPacket();
-  LoRa.print(cwTxBuffer);
-  LoRa.endPacket();
+#ifdef LORA_RADIOLIB
+  int state = radio.transmit(cwTxBuffer);
+  if (state != RADIOLIB_ERR_NONE) {
+    DEBUG(F("Lora TX ERROR!"));
+  }
   if (morseState == loraTrx)
-      LoRa.receive();
+    loraReceived=false; // hack as receive interrupt is also triggered on transmit
+    radio.startReceive();
+#endif
 }
 
 void sendWithWifi() {           // hand this string over as payload to the WiFi transceiver
@@ -2259,7 +2291,9 @@ void sendWithWifi() {           // hand this string over as payload to the WiFi 
   //MorseWiFi::udp.endPacket();
 }
 
-void onLoraReceive(int packetSize){
+void onLoraReceive(){
+#ifdef LORA_RADIOLIB
+  int packetSize = radio.getPacketLength();
   u_int maxl = sizeof(cwTxBuffer) < packetSize ? sizeof(cwTxBuffer) : packetSize;
   String result; 
   String reason = "";
@@ -2268,28 +2302,30 @@ void onLoraReceive(int packetSize){
   result = "";
 
   // received a packet
-  // read packet
-  for (int i = 0; i < maxl; i++)
-  {
-    result += (char)LoRa.read();
+  int state = radio.readData(result, maxl);
+  if (state == RADIOLIB_ERR_NONE) {
+    //DEBUG(F("[SX12xx] Received packet!"));
+    //DEBUG("@2162: 0st byte: " + String(int(result.charAt(0)), BIN ));
+    //DEBUG("@2162: 1st byte: " + String(int(result.charAt(1)), BIN ));
+    //DEBUG("@2162: 2nd byte: " + String(int(result.charAt(2)), BIN ));
+    if (sizeof(cwTxBuffer) < packetSize)
+      reason = "LENGTH";
+    if ((result.charAt(0) & 0b11000000) != 0b01000000)  {     // check protocol version # 
+      reason = "PROT.VER";
+      goto error;
+    }
+    if ((result.charAt(1) & 0b00000011) && packetSize <= sizeof(cwTxBuffer)) {    // 1st actual morse element must not be 0b00
+      //DEBUG("@2170: packetSize: " + String(packetSize));
+        storePacket(radio.getRSSI(), result);
+        return;
+    }
+    if (reason == "")
+      reason = "EOFC";
+    error:    DEBUG("Invalid LoRa Packet: " + reason + "! Discarded...");
+  } else {
+    DEBUG(F("[SX12xx] INVALID PACKET!"));
   }
-  //DEBUG("@2162: 0st byte: " + String(int(result.charAt(0)), BIN ));
-  //DEBUG("@2162: 1st byte: " + String(int(result.charAt(1)), BIN ));
-  //DEBUG("@2162: 2nd byte: " + String(int(result.charAt(2)), BIN ));
-  if (sizeof(cwTxBuffer) < packetSize)
-    reason = "LENGTH";
-  if ((result.charAt(0) & 0b11000000) != 0b01000000)  {     // check protocol version # 
-    reason = "PROT.VER";
-    goto error;
-  }
-  if ((result.charAt(1) & 0b00000011) && packetSize <= sizeof(cwTxBuffer)) {    // 1st actual morse element must not be 0b00
-    //DEBUG("@2170: packetSize: " + String(packetSize));
-      storePacket(LoRa.packetRssi(), result);
-      return;
-  }
-  if (reason == "")
-    reason = "EOFC";
-  error:    DEBUG("Invalid LoRa Packet: " + reason + "! Discarded...");
+#endif
 }
 
 void onWifiReceive(AsyncUDPPacket packet) {

--- a/Software/src/Version 6/morsedefs.h
+++ b/Software/src/Version 6/morsedefs.h
@@ -187,8 +187,64 @@ const int lineOutPin = 17; // for NF line out
 // SENS_FACTOR is used for auto-calibrating sensitivity of touch paddles (somewhere between 2.0 and 2.5)
 #define SENS_FACTOR 2.22
 
+#ifndef BAND
 #define BAND    433E6  //you can set band here directly,e.g. 868E6,915E6
+#endif
 
+#ifndef LORA_DISABLED // this is used to default to lora for Arduino IDE legacy builds
+#define LORA_RADIOLIB
+#endif
+
+#ifdef RADIO_SX1262
+#define RADIO SX1262
+#else
+#define RADIO SX1278
+#define RADIO_SX1278 1
+#endif
+
+// heltec lora v2 pins as defaults
+
+#ifndef LoRa_nss
+#define LoRa_nss 18
+#endif
+
+#ifndef LoRa_dio0
+#define LoRa_dio0 26
+#endif
+
+#ifndef LoRa_dio1
+#define LoRa_dio1 35
+#endif
+
+#ifdef LoRa_dio2
+#define LoRa_dio2 34
+#endif
+
+#ifndef LoRa_MISO
+#define LoRa_MISO 19
+#endif
+
+#ifndef LoRa_MOSI
+#define LoRa_MOSI 27
+#endif
+
+#ifndef LoRa_nrst
+#define LoRa_nrst 14
+#endif
+
+#ifndef LoRa_SCK
+#define LoRa_SCK SCK
+#endif
+
+#ifndef LoRa_busy
+#define LoRa_busy 13
+#endif
+
+/*
+  heltec v2:
+  lora cs: 18
+  lora sck: 5
+*/
 
 ///////////////////////////////////////// END OF HARDWARE DEFS ////////////////////////////////////////////////////////////////////
 

--- a/Software/src/platformio.ini
+++ b/Software/src/platformio.ini
@@ -17,9 +17,11 @@ board = heltec_wifi_lora_32_V2
 framework = arduino
 build_flags =
     -D CORE_DEBUG_LEVEL=0
+    ;-D LORA_DISABLED=1
 monitor_speed = 115200
 monitor_echo = yes
 lib_deps =
 	heltecautomation/Heltec ESP32 Dev-Boards@1.1.2
 	bblanchon/ArduinoJson@6.20.1
 	madhephaestus/ESP32Encoder @ ^0.11.7
+	jgromes/RadioLib@^6.6.0


### PR DESCRIPTION
This PR replaces arduinoLora (included in the heltec library) with radiolib. It defaults to the heltec v2 lora module (sx1278 with proper pin settings). A `LORA_DISABLE` define can be set in pio to bypass all radiolib code (e.g. for the Wifi kit v3). SX1262 can be set via `RADIO_SX1262=1` (this then also need board dependent pin defines for the SX1262 module). 