### PR TITLE
optional I2S and WM8960 support, envs for heltec v3 & vanilla

### DIFF
--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -644,10 +644,12 @@ void displayStartUp(uint16_t volt) {
   MorseOutput::printOnScroll(1, REGULAR, 0, "© 2018-2024");
 
   // uint16_t volt = batteryVoltage(); // has been measured early in setup()
-  
+
+#ifndef SKIP_BATTERY_PROTECT
   if (volt > 1000 && volt < 2800)
     MorseOutput::displayEmptyBattery(shutMeDown);
   else 
+#endif
     MorseOutput::displayBatteryStatus(volt);
   //prepare board version, just in case we want to switch to M32protocol later on
   if (MorsePreferences::boardVersion == 3)

--- a/Software/src/platformio.ini
+++ b/Software/src/platformio.ini
@@ -10,19 +10,153 @@
 
 [platformio]
 src_dir=Version 6
+default_envs=heltec_wifi_lora_32_V2
+
+[common]
+lib_deps_external =
+  thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.6.1
+  bblanchon/ArduinoJson@6.20.1
+  madhephaestus/ESP32Encoder @ ^0.11.7
 
 [env:heltec_wifi_lora_32_V2]
 platform = espressif32
 board = heltec_wifi_lora_32_V2
 framework = arduino
-build_flags =
-    -D CORE_DEBUG_LEVEL=0
-    ;-D LORA_DISABLED=1
-
 monitor_speed = 115200
 monitor_echo = yes
+upload_speed = 921600
+build_flags =
+    -D CORE_DEBUG_LEVEL=0
+
 lib_deps =
-	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.6.1
-	bblanchon/ArduinoJson@6.20.1
-	madhephaestus/ESP32Encoder @ ^0.11.7
-	jgromes/RadioLib@^6.6.0
+  ${common.lib_deps_external}
+  jgromes/RadioLib@^7.1.0
+
+[env:heltec_wifi_kit_32_V3]
+platform=espressif32
+board=heltec_wifi_kit_32_V3
+framework=arduino
+monitor_speed = 115200
+monitor_echo = yes
+upload_speed = 921600
+
+build_flags =
+;  -D CORE_DEBUG_LEVEL=0
+  -D INTERNAL_PULLUP=1
+  -D SKIP_BATTERY_PROTECT=1
+  -D LORA_DISABLED=1
+  -D OLED_SDA=17
+  -D OLED_SCL=18
+  -D OLED_RST=21
+  -D PIN_VEXT=36
+  -D PIN_ADC_CTRL=37
+  -D PIN_ROT_DT=33
+  -D PIN_ROT_CLK=47
+  -D PIN_ROT_BTN=34
+  -D PIN_PADDLE_LEFT=19
+  -D PIN_PADDLE_RIGHT=48
+  -D PIN_TOUCH_LEFT=4
+  -D PIN_TOUCH_RIGHT=5
+  -D PIN_BATTERY=1
+  -D PIN_KEYER=35
+  -D PIN_AUDIO_IN=-1
+  -D CONFIG_SOUND_I2S=1
+  -D CONFIG_I2S_BCK_PIN=41
+  -D CONFIG_I2S_LRCK_PIN=42
+  -D CONFIG_I2S_DATA_PIN=45
+  -D CONFIG_I2S_DATA_IN_PIN=46
+  -D CONFIG_WM8960=1
+  -D CONFIG_WM8960_SDA=7
+  -D CONFIG_WM8960_SCL=6
+
+lib_deps =
+  ${common.lib_deps_external}
+	https://github.com/haklein/cw-i2s-sidetone.git
+  WiFiClientSecure
+  sparkfun/SparkFun WM8960 Arduino Library@^1.0.4
+
+[env:heltec_wifi_lora_32_V3]
+platform=espressif32
+board=heltec_wifi_lora_32_V3
+framework=arduino
+monitor_speed = 115200
+monitor_echo = yes
+upload_speed = 921600
+
+build_flags =
+;  -D CORE_DEBUG_LEVEL=0
+  -D INTERNAL_PULLUP=1
+  -D SKIP_BATTERY_PROTECT=1
+  -D OLED_SDA=17
+  -D OLED_SCL=18
+  -D OLED_RST=21
+  -D PIN_VEXT=36
+  -D PIN_ADC_CTRL=37
+  -D PIN_ROT_DT=42
+  -D PIN_ROT_CLK=45
+  -D PIN_ROT_BTN=41
+  -D PIN_PADDLE_LEFT=46
+  -D PIN_PADDLE_RIGHT=34
+  -D PIN_TOUCH_LEFT=2
+  -D PIN_TOUCH_RIGHT=3
+  -D PIN_BATTERY=1
+  -D PIN_KEYER=40
+  -D PIN_KEYER_LED=35
+  -D PIN_AUDIO_IN=-1
+  -D CONFIG_SOUND_I2S=1
+  -D CONFIG_I2S_BCK_PIN=4
+  -D CONFIG_I2S_LRCK_PIN=5
+  -D CONFIG_I2S_DATA_PIN=6
+  -D CONFIG_I2S_DATA_IN_PIN=7
+  -D CONFIG_WM8960=1
+  -D CONFIG_WM8960_SDA=33
+  -D CONFIG_WM8960_SCL=47
+	-D LoRa_MOSI=10
+	-D LoRa_MISO=11
+	-D LoRa_SCK=9
+	-D LoRa_nss=8
+	-D LoRa_dio1=14
+	-D LoRa_nrst=12
+	-D LoRa_busy=13
+  -D RADIO_SX1262=1
+
+lib_deps =
+  ${common.lib_deps_external}
+  https://github.com/haklein/cw-i2s-sidetone.git
+  WiFiClientSecure
+  sparkfun/SparkFun WM8960 Arduino Library@^1.0.4
+  jgromes/RadioLib@^7.1.0
+
+[env:vanilla]
+platform=espressif32
+board=heltec_wifi_lora_32_V3
+framework=arduino
+monitor_speed = 115200
+monitor_echo = yes
+upload_speed = 921600
+
+build_flags =
+;  -D CORE_DEBUG_LEVEL=0
+  -D INTERNAL_PULLUP=1
+  -D SKIP_BATTERY_PROTECT=1
+  -D SKIP_LEGACY_PINDEFS=1
+  -D LORA_DISABLED=1
+  -D TOUCHPADDLES_DISABLED=1
+  -D OLED_SDA=18
+  -D OLED_SCL=17
+  -D PIN_ROT_DT=42
+  -D PIN_ROT_CLK=45
+  -D PIN_ROT_BTN=41
+  -D PIN_PADDLE_LEFT=38
+  -D PIN_PADDLE_RIGHT=39
+  -D PIN_KEYER=35
+  -D CONFIG_SOUND_I2S=1
+  -D CONFIG_I2S_BCK_PIN=6
+  -D CONFIG_I2S_LRCK_PIN=5
+  -D CONFIG_I2S_DATA_PIN=4
+  -D CONFIG_I2S_DATA_IN_PIN=7
+
+lib_deps =
+  ${common.lib_deps_external}
+  https://github.com/haklein/cw-i2s-sidetone.git
+  WiFiClientSecure


### PR DESCRIPTION
This adds basic I2S support for sidetone (optional per `CONFIG_AUDIO_I2S`) and WM8960 support (optional per `CONFIG_WM8960`). Also adds platformio.ini environments with pin definitions for Wifi kit v3, Lora v3 and vanilla.