### PR TITLE
add audio suspend method to power down WM8960 codec

### DIFF
--- a/Software/src/Version 6/MorseOutput.cpp
+++ b/Software/src/Version 6/MorseOutput.cpp
@@ -735,6 +735,13 @@ void MorseOutput::soundSetup()
 #endif
 }
 
+void MorseOutput::soundSuspend()
+{
+#ifdef CONFIG_WM8960
+  codec.disableVREF();
+  codec.disableVMID();
+#endif
+}
 
 void MorseOutput::pwmTone(unsigned int frequency, unsigned int volume, boolean lineOut) { // frequency in Hertz, volume in range 0 - 19; we use 10 bit resolution
 #ifndef CONFIG_SOUND_I2S

--- a/Software/src/Version 6/MorseOutput.h
+++ b/Software/src/Version 6/MorseOutput.h
@@ -56,6 +56,7 @@ namespace MorseOutput
   void resetTOT();
 
   void soundSetup();
+  void soundSuspend();
   void pwmTone(unsigned int frequency, unsigned int volume, boolean lineOut);
   void pwmNoTone(unsigned int volume);
   void pwmClick(unsigned int volume);

--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -2235,6 +2235,7 @@ void shutMeDown() {
 #endif
   WiFi.disconnect(true, false);
   delay(100);
+  MorseOutput::soundSuspend();
 #ifdef PIN_VEXT
   digitalWrite(PIN_VEXT,HIGH);
   delay(100);


### PR DESCRIPTION
adds a method to power down the WM8960. This is called in shutMeDown().