### PR TITLE
add support for TI TLV320AIC3100 codec

### DIFF
--- a/Software/src/Version 6/MorseOutput.h
+++ b/Software/src/Version 6/MorseOutput.h
@@ -56,6 +56,9 @@ namespace MorseOutput
   void resetTOT();
 
   void soundSetup();
+#ifdef CONFIG_TLV320AIC3100
+  void soundEventHandler();
+#endif
   void soundSuspend();
   void pwmTone(unsigned int frequency, unsigned int volume, boolean lineOut);
   void pwmNoTone(unsigned int volume);

--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -325,6 +325,13 @@ uint8_t cwTxSerial;                                     /// a 6 bit serial numbe
 
 IPAddress peerIP;
 
+#ifdef CONFIG_TLV320AIC3100_INT
+volatile bool codec_event = false;
+void IRAM_ATTR codec_isr() {
+  codec_event = digitalRead(CONFIG_TLV320AIC3100_INT) == HIGH ? true : false;
+}
+#endif
+
 /*
 ////////////////////////////////////////////////////////////////////
 // encoder subroutines
@@ -491,6 +498,10 @@ void setup()
   MorseOutput::clearDisplay();
   MorseOutput::soundSetup();
 
+#ifdef CONFIG_TLV320AIC3100_INT
+  pinMode(CONFIG_TLV320AIC3100_INT, INPUT);
+  attachInterrupt(CONFIG_TLV320AIC3100_INT, codec_isr, RISING);
+#endif
 
   rotaryEncoder.attachHalfQuad ( PinDT, PinCLK );
   rotaryEncoder.setCount ( 0 );
@@ -935,7 +946,13 @@ void loop() {
       onLoraReceive();
     }
 #endif
-    
+
+#ifdef CONFIG_TLV320AIC3100_INT
+    if (codec_event) {
+      codec_event = false;
+      MorseOutput::soundEventHandler();
+    }
+#endif
 }     /////////////////////// end of loop() /////////
 
 


### PR DESCRIPTION
This feature PR adds support for the Texas Instruments TLV320AIC3100 codec. The code can be enabled with `CONFIG_TLV320AIC3100=1`.  I2C pins are specified via `CONFIG_TLV320AIC3100_SDA` and `CONFIG_TLV320AIC3100_SCL`. When the codec interrupt pin is connected, specifying `CONFIG_TLV320AIC3100_INT` will set up an interrupt handler to act upon the headset detect interrupt. Add https://github.com/haklein/tlv320aic31xx.git to the `lib_deps` to pull the latest codec configuration library.
