### PR TITLE
Add MorsePref option to select output case

### DIFF
--- a/Software/src/Version 6/MorsePreferences.cpp
+++ b/Software/src/Version 6/MorsePreferences.cpp
@@ -45,7 +45,7 @@ Preferences pref;               // use the Preferences library for storing and r
       posGeneratorDisplay, posWordDoubler, posEchoDisplay, posEchoRepeats,  posEchoConf,            // 16
       posKeyExternalTx, posLoraCwTransmit, posGoertzelBandwidth, posSpeedAdapt,                     // 21
       posKochSeq, posCarouselStart, posLatency, posRandomFile, posExtAudioOnDecode, posTimeOut,     // 25
-      posQuickStart, posAutoStop, posMaxSequence, posLoraChannel,   posSerialOut,                   // 31
+      posQuickStart, posOutputCase, posAutoStop, posMaxSequence, posLoraChannel,   posSerialOut,    // 31
       // to be treated differently:
       posKochFilter,                                                                                // 36
       posLoraBand, posLoraQRG, posSnapRecall, posSnapStore,  posVAdjust, posHwConf, posScreen                  // 37
@@ -59,7 +59,7 @@ const char * prefName[] = {"encoderClicks", "sidetoneFreq", "useExtPaddle", "did
                       "GeneratorDispl", "wordDoubler", "echoDisplay", "echoRepeats", "echoConf",
                       "KeyExternalTx", "LoraCwTransmit", "goertzelBW", "speedAdapt",
                       "KochSeq", "carouselStart", "latency", "randomFile", "extAudioOnDecod", "timeOut",
-                      "quickStart", "autoStop", "maxSequence", "LoraChannel",
+                      "quickStart", "outputCase", "autoStop", "maxSequence", "LoraChannel"
 #ifdef CONFIG_BLUETOOTH_KEYBOARD
 					  "bluetoothOut",
 #endif
@@ -310,6 +310,13 @@ parameter MorsePreferences::pliste[] = {
     {"OFF", "ON"}
   },
   {
+    0, 0, 1, 1,                                                 // What character case should decoded output be printed
+    "Output Case",
+    "Upper or lower case Decoded Morse output",
+    true,
+    {"lower", "UPPER"}
+  },
+  {
     0, 0, 1, 1,                                                 // Stop after each word in CW generator modes?
     "Stop<Next>Rep",
     "Stop after each word; choose repeat or next word with paddle",
@@ -428,9 +435,9 @@ uint8_t MorsePreferences::memCounter;
 uint8_t MorsePreferences::memPtr = 0;
 
 #ifdef CONFIG_BLUETOOTH_KEYBOARD
-#define PREFPOS_COMMON_CORE posClicks, posPitch, posTimeOut, posQuickStart, posBluetoothOut, posSerialOut, posPolarity, posExtPddlPolarity
+#define PREFPOS_COMMON_CORE posClicks, posPitch, posTimeOut, posQuickStart, posOutputCase, posBluetoothOut, posSerialOut, posPolarity, posExtPddlPolarity
 #else
-#define PREFPOS_COMMON_CORE posClicks, posPitch, posTimeOut, posQuickStart, posSerialOut, posPolarity, posExtPddlPolarity
+#define PREFPOS_COMMON_CORE posClicks, posPitch, posTimeOut, posQuickStart, posOutputCase, posSerialOut, posPolarity, posExtPddlPolarity
 #endif
   prefPos MorsePreferences::keyerOptions[] =     { PREFPOS_COMMON_CORE,
                                                    posCurtisMode, posCurtisBDahTiming, posCurtisBDotTiming, posACS,  posLatency
@@ -485,7 +492,7 @@ uint8_t MorsePreferences::memPtr = 0;
                                                    posGoertzelBandwidth, posExtAudioOnDecode
                                                  };
 
- prefPos MorsePreferences::decoderOptions[] =    { posClicks, posPitch, posTimeOut, posQuickStart, posSerialOut,
+ prefPos MorsePreferences::decoderOptions[] =    { posClicks, posPitch, posTimeOut, posQuickStart, posOutputCase, posSerialOut,
                                                    posCurtisMode, posGoertzelBandwidth, posExtAudioOnDecode
                                                  };
 

--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -2033,14 +2033,18 @@ void fetchNewWord() {
 /// the next function is used to display KEYED and DECODED characters
 
 void displayDecodedMorse(String symbol, boolean keyed) {
-
+  String tmp_str = symbol;
+  if (MorsePreferences::pliste[posOutputCase].value) {
+    tmp_str.toUpperCase();
+  }
   // output  the symbol; flush if not morseGenerator, otherwise if not autostop
-  MorseOutput::printToScroll( REGULAR, symbol, true, encoderState == scrollMode);
+  MorseOutput::printToScroll( REGULAR, tmp_str, true, encoderState == scrollMode);
 
-  SerialOutMorse(symbol, keyed ? 0b001 : 0b010);
+  SerialOutMorse(tmp_str, keyed ? 0b001 : 0b010);
+
 #ifdef CONFIG_BLUETOOTH_KEYBOARD
   if ((MorsePreferences::pliste[posBluetoothOut].value & 0x2) == 0x2)
-    MorseBluetooth::bluetoothTypeString(symbol);
+    MorseBluetooth::bluetoothTypeString(tmp_str);
 #endif
 
   if (morseState == echoTrainer) {                /// store the character in the response string
@@ -2058,7 +2062,6 @@ void displayDecodedMorse(String symbol, boolean keyed) {
     else if (symbol != " ")
       echoResponse.concat(symbol);
      //DEBUG("@1795: echoResponse: " + echoResponse);
-
   }
 }   /// end of displayDecodedMorse()
 
@@ -2066,15 +2069,18 @@ void displayDecodedMorse(String symbol, boolean keyed) {
 
 //// the next function is used to display GENERATED characters
 
-void displayGeneratedMorse(FONT_ATTRIB style, String s) {
-   MorseOutput::printToScroll(style, s, true, encoderState == scrollMode);
-   SerialOutMorse(s, 0b100); // dec 4
+void displayGeneratedMorse(FONT_ATTRIB style, String s)
+{
+	if (MorsePreferences::pliste[posOutputCase].value) {
+		s.toUpperCase();
+	}
+	MorseOutput::printToScroll(style, s, true, encoderState == scrollMode);
+	SerialOutMorse(s, 0b100); // dec 4
 #ifdef CONFIG_BLUETOOTH_KEYBOARD
-   if ((MorsePreferences::pliste[posBluetoothOut].value & 0x2) == 0x2)
+	if ((MorsePreferences::pliste[posBluetoothOut].value & 0x2) == 0x2)
 		MorseBluetooth::bluetoothTypeString(s);
 #endif
 }
-
 
 /// send chars to serial port, if appropriate
 
@@ -2519,7 +2525,7 @@ void onEspnowRecv(const uint8_t* mac, const uint8_t* data, uint8_t len, signed i
     return;
   u_int maxl = sizeof(cwTxBuffer) < len ? sizeof(cwTxBuffer) : len;
   String result;
-  
+
   result.reserve(sizeof(cwTxBuffer));   // we should never receive a packet longer than the sender is allowed to send!
   result = "";
 
@@ -2531,7 +2537,7 @@ void onEspnowRecv(const uint8_t* mac, const uint8_t* data, uint8_t len, signed i
   //DEBUG("@2178: protocol version = " + String((result.charAt(1) & 0b11000000)));
 
   if (len <= sizeof(cwTxBuffer))
-      storePacket(rssi, result);     
+      storePacket(rssi, result);
   else
       DEBUG("ESPNOW Packet longer than sizeof(cwTxBuffer) bytes! Discarded...");
 }

--- a/Software/src/Version 6/morsedefs.h
+++ b/Software/src/Version 6/morsedefs.h
@@ -356,7 +356,7 @@ enum prefPos : uint8_t {
                 posGeneratorDisplay, posWordDoubler, posEchoDisplay, posEchoRepeats,  posEchoConf,            // 16
                 posKeyExternalTx, posLoraCwTransmit, posGoertzelBandwidth, posSpeedAdapt,                     // 21
                 posKochSeq, posCarouselStart, posLatency, posRandomFile, posExtAudioOnDecode, posTimeOut,     // 25
-                posQuickStart, posAutoStop,posMaxSequence, posLoraChannel,                                    // 31
+                posQuickStart, posOutputCase, posAutoStop, posMaxSequence, posLoraChannel,                    // 31
 #ifdef CONFIG_BLUETOOTH_KEYBOARD
 				posBluetoothOut,
 #endif


### PR DESCRIPTION
Change-Id: I232e76d5e1dccf2bd02eb1ecb387f26cbb8420b7

Adds a MorsePrefs variable to allow user choice for output casing.  Changes to check that variable and output either lower or UPPPER cased output for screen, serial, & bluetooth outputs.

This change is for Reginald.  I think it should make him happy. :-)