### PR TITLE
add env for pocketwroom-lora

### DIFF
--- a/Software/src/platformio.ini
+++ b/Software/src/platformio.ini
@@ -267,6 +267,23 @@ build_flags =
 lib_deps =
 	${common.M32_Pocket_DW_TIsnd_board_lib_deps}
 
+[env:pocketwroom-lora]
+extends=env:pocketwroom
+build_unflags =
+	-D TFT_MISO=-1
+	-D LORA_DISABLED=1  ; We need LORA so pull the disable from the defaults
+build_flags =
+	${env:pocketwroom.build_flags}
+ 	-D RADIO_SX1262=1 ; Heltec HT-RA62 module uses the SX1262
+  	-D TFT_MISO=36 ; can't be -1 but needs to match LoRa_MISO for shared SPI
+   	-D LoRa_MOSI=48
+	-D LoRa_MISO=36
+	-D LoRa_SCK=38
+	-D LoRa_nss=37
+	-D LoRa_dio1=44
+	-D LoRa_nrst=43
+	-D LoRa_busy=35
+	-D HW_NAME="M32 Pocket (Wroom LoRa)"
 
 [env:pocketwroom-170x240]
 extends=env:pocketwroom


### PR DESCRIPTION
Adds required env definition for the optional Heltec HT-RA62 LoRa module on the back of the pocketwroom PCB