### PR TITLE
add optional support for TLV320* reset via pin

### DIFF
--- a/Software/src/Version 6/m32_v6.ino
+++ b/Software/src/Version 6/m32_v6.ino
@@ -528,6 +528,13 @@ digitalWrite(PIN_VEXT, VEXT_ON_VALUE);
   MorseOutput::setBrightness(MorsePreferences::oledBrightness);
   MorseOutput::clearDisplay();
   scrollTop = MorseOutput::getScrollTop();
+#ifdef CONFIG_TLV320AIC3100_RST
+  pinMode(CONFIG_TLV320AIC3100_RST, OUTPUT);
+  digitalWrite(CONFIG_TLV320AIC3100_RST, LOW);
+  delay(100);
+  digitalWrite(CONFIG_TLV320AIC3100_RST, HIGH);
+  delay(100);
+#endif
   MorseOutput::soundSetup();
 
 #ifdef CONFIG_TLV320AIC3100_INT


### PR DESCRIPTION
Allows optional reset pin define via CONFIG_TLV320AIC3100_RST - required e.g. for the Adafruit TLV320DAC3100 board as this doesn't integrate a reset chip. Tested with pin 45, that would even be free on the pocketwroom, so future designs could possibly do without reset chip (assuming this would route to the required spot on the current board)