### PR TITLE
FIX beta date to YYMMDD, optimized string handling and added overflow…

### DIFF
--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -693,15 +693,15 @@ boolean checkKey () {
 }
 
 
-// shorter date format
-String  shortDate(char const *date) { 
-    int month, day, year;
-    char buff[7]; // buffer for everything we need to print
+// shorter date format "Mmm dd yyyy" "Oct 21 2027" -> "YYMMDD"
+String  shortDate(char const *date) {
     static const char month_names[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
-    sscanf(date, "%s %d %d", buff, &day, &year);
-    month = (strstr(month_names, buff)-month_names)/3+1;
-    year -= 2000; // convert to 2 digit year
-    sprintf(buff, "%02d%02d%02d", day, month, year);
+    int day, year, month = 0;
+    char buff[7]; // buffer for YYMMDD + \0
+    if (sscanf(date, "%3s %d %d", buff, &day, &year) != 3) return "000000";
+    char *p = strstr(month_names, buff);
+    if (p) month = (p - month_names) / 3 + 1;
+    snprintf(buff, sizeof(buff), "%02d%02d%02d", year % 100, month, day);
     return String (buff);
 }
 // display startup screen and check battery status, also send device information if M32 serial protocol is being used
@@ -723,13 +723,21 @@ void displayStartUp(uint16_t volt) {
 #endif
   MorseOutput::printOnStatusLine( true, 0, s);
   s = "V" ;
-  vsn = String(VERSION_MAJOR) + "." + String(VERSION_MINOR) ;
-  if (VERSION_PATCH != 0)
-    vsn = vsn + "." + String(VERSION_PATCH);
-  if (BETA) 
-    vsn = vsn + " beta " + shortDate(COMPILEDATE);
-  s += vsn;
-  MorseOutput::printOnScroll(0, REGULAR, 0, s );
+  s += VERSION_MAJOR;
+  s += ".";
+  s += VERSION_MINOR;
+
+  if (VERSION_PATCH != 0) {
+    s += ".";
+    s += VERSION_PATCH;
+  }
+
+  if (BETA) {
+    s += " beta ";
+    s += shortDate(COMPILEDATE);
+  }
+
+  MorseOutput::printOnScroll(0, REGULAR, 0, s);
   MorseOutput::printOnScroll(1, REGULAR, 0, COPYRIGHT);
 
   // uint16_t volt = batteryVoltage(); // has been measured early in setup()

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -824,7 +824,7 @@ void displayStartUp(uint16_t volt) {
   }
 
   if (BETA) {
-    s += " beta ";
+    s += "b ";
     s += shortDate(COMPILEDATE);
   }
 


### PR DESCRIPTION
… protection to shortDate/startup logic

It hasn't been compiled yet, I am not sure if you are using VS Code + PlatformIO, Espressif ESP-IDF, or maybe even Arduino IDE?
Do you have any instructions on how to build it? 73 Tom

Failure:
Previously: With the beta version from 2026-04-28:
Output on the display: "V8.0 beta 280426"
Now the display should show: "V8.0 beta 260428"