### PR TITLE
Fix false stuck-keyer reset that drops long characters at slow WPM

### DIFF
--- a/Software/src/Version 6 and newer/MorseGame.cpp
+++ b/Software/src/Version 6 and newer/MorseGame.cpp
@@ -783,12 +783,16 @@ static void statePlaying() {
             doPaddleIambic(leftKey, rightKey);
             updateSound();
 
-            // Track keyer idle state for stuck detection
+            // Track keyer idle state for stuck detection.
+            // Threshold scales with ditLength: long characters at slow speeds
+            // (e.g. '0' = ----- at 12 wpm = ~2 s) must not trip a false reset,
+            // which would silently drop the character and leave the sidetone on.
+            unsigned long stuckThreshold = max(3000UL, 30UL * (unsigned long)ditLength);
             if (keyerState == IDLE_STATE) {
                 lastIdleTime = millis();
-            } else if (!leftKey && !rightKey && millis() - lastIdleTime > 2000) {
-                // Keyer has been running for >2s with no paddles pressed — stuck.
-                // Force reset to prevent runaway dit/dah stream.
+            } else if (!leftKey && !rightKey && millis() - lastIdleTime > stuckThreshold) {
+                // Keyer has been running with no paddles pressed for far longer
+                // than any legal character — genuinely stuck. Force reset.
                 keyerState = IDLE_STATE;
                 clearPaddleLatches();
                 lastIdleTime = millis();

--- a/Software/src/Version 6 and newer/MorseRadioCave.cpp
+++ b/Software/src/Version 6 and newer/MorseRadioCave.cpp
@@ -1937,11 +1937,14 @@ static void parserTick() {
     doPaddleIambic(leftKey, rightKey);
 
     // Stuck-keyer protection (same as Morse Invaders).
-    // Long idle periods between commands make this more likely here.
+    // Threshold scales with ditLength: long characters at slow speeds
+    // (e.g. '0' = ----- at 12 wpm = ~2 s) must not trip a false reset,
+    // which would silently drop the character and leave the sidetone on.
     static unsigned long lastIdleTime = 0;
+    unsigned long stuckThreshold = max(3000UL, 30UL * (unsigned long)ditLength);
     if (keyerState == IDLE_STATE) {
         lastIdleTime = millis();
-    } else if (!leftKey && !rightKey && millis() - lastIdleTime > 2000) {
+    } else if (!leftKey && !rightKey && millis() - lastIdleTime > stuckThreshold) {
         keyerState = IDLE_STATE;
         clearPaddleLatches();
         lastIdleTime = millis();


### PR DESCRIPTION
## Summary
- Morse Invaders and Radio Cave used a fixed 2-second threshold to detect a "stuck" keyer and force-reset it.
- At 12 wpm the longest legal characters (`0` = `-----`, `,` = `--..--`) take ~2000 ms to key, so the guard tripped right at the end of the character.
- The forced reset only sets `keyerState = IDLE_STATE` — it does not call `keyOut(false)` or `displayDecodedMorse()` — so the dah's sidetone kept playing and the decoded character was silently dropped, making the invader look "missed" despite correct keying.
- Fix: scale the threshold with `ditLength` (`max(3000, 30 * ditLength)`) so it stays comfortably above any legal character at every supported speed while still catching genuine runaway states.

## Test plan
- [ ] Play Morse Invaders at 12 wpm and key `0`, `,`, `9`, `8` repeatedly — invaders should be destroyed and the sidetone should stop cleanly.
- [ ] Confirm at 17 wpm behaviour is unchanged.
- [ ] Confirm Radio Cave keying at slow WPM no longer drops long characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)