### PR TITLE
Restore display state when Radio Cave's sprite allocation fails

### DIFF
--- a/Software/src/Version 6 and newer/MorseMenu.cpp
+++ b/Software/src/Version 6 and newer/MorseMenu.cpp
@@ -610,17 +610,22 @@ boolean MorseMenu::menuExec() {       // return true if we should  leave menu af
       case _morseInvaders:
                 MorseGame::run();
                 m32state = menu_loop;
+                // Clear both buttons: a long-press exit leaves clicks == -1, which
+                // would trigger an immediate exit in the next game's lobby guard.
                 Buttons::modeButton.clicks = 0;
+                Buttons::volButton.clicks  = 0;
                 return false;
       case _fightPileup:
                 MorsePileup::run();
                 m32state = menu_loop;
                 Buttons::modeButton.clicks = 0;
+                Buttons::volButton.clicks  = 0;
                 return false;
       case _radioCave:
                 MorseRadioCave::run();
                 m32state = menu_loop;
                 Buttons::modeButton.clicks = 0;
+                Buttons::volButton.clicks  = 0;
                 return false;
 #endif  
       case  _decode: /// decoder


### PR DESCRIPTION
## Summary

Fix the bug where, after playing Morse Invaders or Fight the Pileup, trying to enter Radio Cave makes the screen flicker and returns the user to the main menu — sometimes with the menu now displayed rotated 90°.

## Root cause

The `DisplayWrapper` library allocates two separate sprites that both persist for the device's lifetime once allocated:

- `_gameSprite` — portrait, ~106 KB (Invaders, Pileup)
- `_gameSpriteLandscape` — ~106 KB (Radio Cave)

Both come from internal SRAM (`setPsram(false)`). On the M32 Pocket there isn't enough contiguous internal SRAM to hold both, so after a portrait session has run, `createSprite()` inside `enterGameModeLandscape()` fails and returns `nullptr` to `MorseRadioCave::run()`. The previous code at the top of `run()` was simply `if (!canvas) return;`. `enterGameModeLandscape` had already changed the panel rotation to landscape **before** the failed sprite allocation, so this early return left the menu running with the panel still rotated 90°.

## Fix in this PR

When `enterGameModeLandscape` returns null:

- restore rotation, theme, encoder pins, and run `MorseOutput::initDisplay()` (same sequence the normal exit path uses);
- show a brief "Out of memory. Reboot to play." message so the failure isn't silent;
- return.

This is defensive — the actual root cause needs to be fixed in `DisplayWrapper`.

## Companion fix in DisplayWrapper

The real fix is [oe1wkl/DisplayWrapper#1](https://github.com/oe1wkl/DisplayWrapper/pull/1), which frees the unused-orientation sprite on each `enterGameMode*()` call so the two never compete for memory. Once that PR is merged and the new commit is pulled in via PlatformIO, Radio Cave will be enterable again after Invaders/Pileup. The defensive handling in this PR remains useful as belt-and-braces protection against any future allocation failure.

## Also in this PR

The first commit clears `Buttons::volButton.clicks = 0` alongside the existing `modeButton.clicks = 0` after every game returns, mirroring the cleanup `MorsePileup::run()` already does internally. This was an earlier hypothesis — it turned out not to be the cause of the Radio Cave bug, but the cleanup is consistent with the rest of the codebase.

## Test plan

- [ ] After the DisplayWrapper PR is merged: Invaders → exit → Radio Cave should start cleanly.
- [ ] Without the DisplayWrapper PR: Invaders → exit → Radio Cave shows "Out of memory. Reboot to play." for ~2.5 s, menu returns in correct (portrait) orientation.
- [ ] Radio Cave → exit (long-press) → menu in correct orientation (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)