### PR TITLE
Restore display state when Radio Cave's sprite allocation fails

### DIFF
--- a/Software/src/Version 6 and newer/MorseRadioCave.cpp
+++ b/Software/src/Version 6 and newer/MorseRadioCave.cpp
@@ -2707,7 +2707,35 @@ static void playLoop() {
 
 void MorseRadioCave::run() {
     canvas = display.enterGameModeLandscape(MorsePreferences::leftHanded);
-    if (!canvas) return;
+    if (!canvas) {
+        // Sprite allocation failed. Most common cause: the portrait sprite
+        // from a previous Invaders/Pileup session is still holding ~100 KB
+        // of internal SRAM, leaving no contiguous block for the ~100 KB
+        // landscape sprite. enterGameModeLandscape already changed the
+        // panel rotation before the allocation attempt, so we have to
+        // restore the menu's orientation — otherwise the Morserino menu
+        // ends up displayed rotated 90°.
+        //
+        // Use the same restore sequence as the normal exit path below.
+        DisplayWrapper::getLGFX()->setRotation(MorsePreferences::leftHanded ? 0 : 2);
+        MorseOutput::initDisplay();
+        #ifdef CONFIG_DISPLAYWRAPPER
+        MorseOutput::setTheme(MorsePreferences::pliste[posTheme].value);
+        #endif
+        pinMode(PinCLK, INPUT_PULLUP);
+        pinMode(PinDT,  INPUT_PULLUP);
+        rotaryEncoder.attachHalfQuad(PinDT, PinCLK);
+        rotaryEncoder.setCount(0);
+
+        MorseOutput::clearDisplay();
+        MorseOutput::printOnScroll(0, BOLD,    0, "Radio Cave");
+        MorseOutput::printOnScroll(1, REGULAR, 0, "Out of memory.");
+        MorseOutput::printOnScroll(2, REGULAR, 0, "Reboot to play.");
+        MorseOutput::refreshDisplay();
+        delay(2500);
+        MorseOutput::clearDisplay();
+        return;
+    }
 
     rcState = RC_LOBBY;
 


### PR DESCRIPTION
## Summary

Defensive fix for the bug where, after playing Morse Invaders or Fight the Pileup, trying to enter Radio Cave makes the screen flicker and returns the user to the main menu — sometimes with the menu now displayed rotated 90°.

(This is the follow-up that should have been part of [#147](https://github.com/oe1wkl/Morserino-32/pull/147) but was pushed after that PR was already merged, so it never made it onto master. Same change as before, opened as a fresh PR off current master.)

## Root cause

The `DisplayWrapper` library allocates two separate sprites that both persist for the device's lifetime once allocated:

- `_gameSprite` — portrait, ~106 KB (Invaders, Pileup)
- `_gameSpriteLandscape` — ~106 KB (Radio Cave)

Both come from internal SRAM (`setPsram(false)`). On the M32 Pocket there isn't enough contiguous internal SRAM to hold both, so after a portrait session has run, `createSprite()` inside `enterGameModeLandscape()` fails and returns `nullptr` to `MorseRadioCave::run()`. The previous code at the top of `run()` was simply `if (!canvas) return;`. `enterGameModeLandscape` had already changed the panel rotation to landscape **before** the failed sprite allocation, so this early return left the menu running with the panel still rotated 90°.

## Fix in this PR

When `enterGameModeLandscape` returns null:

- restore rotation, theme, encoder pins, and run `MorseOutput::initDisplay()` (same sequence the normal exit path uses);
- show a brief "Out of memory. Reboot to play." message so the failure isn't silent;
- return cleanly.

## Companion fix in DisplayWrapper

The actual root cause is fixed in [oe1wkl/DisplayWrapper#1](https://github.com/oe1wkl/DisplayWrapper/pull/1), which frees the unused-orientation sprite on each `enterGameMode*()` call so the two never compete for memory. Once that PR is merged and PlatformIO pulls in the new commit, Radio Cave will be enterable again after Invaders/Pileup. The defensive handling in this PR remains useful as belt-and-braces protection against any future allocation failure.

## Test plan

- [ ] Without DisplayWrapper#1: Invaders → exit → Radio Cave shows "Out of memory. Reboot to play." for ~2.5 s, then menu returns in correct (portrait) orientation (regression of the 90°-rotated menu symptom).
- [ ] With DisplayWrapper#1 merged and pulled: Invaders → exit → Radio Cave starts cleanly.
- [ ] Radio Cave → exit (long-press) → menu in correct orientation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)