### PR TITLE
M32 owns the game-mode sprite (fixes Radio Cave OOM)

### DIFF
--- a/Software/src/Version 6 and newer/MorseGame.cpp
+++ b/Software/src/Version 6 and newer/MorseGame.cpp
@@ -7,6 +7,7 @@
  *****************************************************************************************************************************/
 
 #include "MorseGame.h"
+#include "MorseGameMode.h"
 
 // Always defined (even without CONFIG_CW_GAME)
 bool gameMode = false;
@@ -454,7 +455,7 @@ static char pollKeyedChar() {
 // Drawing
 //=============================================================================
 
-static void pushFrame() { display.pushGameFrame(); }
+static void pushFrame() { MorseGameMode::pushFrame(); }
 
 static void drawCentredText(int y, const char* text, uint16_t color,
                             const lgfx::IFont* font) {
@@ -1021,7 +1022,8 @@ static void stateGameOver() {
 //=============================================================================
 
 void MorseGame::run() {
-    canvas = display.enterGameMode(false);    if (!canvas) return;
+    canvas = MorseGameMode::enterPortrait(false);
+    if (!canvas) return;
     // Determine character rotation from preference
     // posInvaderOrient: 0 = game native (no rotation), 1 = reading orientation
     #ifdef CONFIG_DISPLAYWRAPPER
@@ -1073,17 +1075,7 @@ void MorseGame::run() {
         tileSprite = nullptr;
     }
 
-    display.exitGameMode();
-
-    // Restore normal display for menu
-    MorseOutput::initDisplay();
-    #ifdef CONFIG_DISPLAYWRAPPER
-    MorseOutput::setTheme(MorsePreferences::pliste[posTheme].value);
-    #endif
-    // Restore encoder pins after MorseOutput::initDisplay() claimed SPI
-    pinMode(PinCLK, INPUT_PULLUP);
-    pinMode(PinDT, INPUT_PULLUP);
-    rotaryEncoder.attachHalfQuad(PinDT, PinCLK);
-    rotaryEncoder.setCount(0);}
+    MorseGameMode::exit();
+}
 
 #endif  // CONFIG_CW_GAME

--- a/Software/src/Version 6 and newer/MorseGameMode.cpp
+++ b/Software/src/Version 6 and newer/MorseGameMode.cpp
@@ -1,0 +1,106 @@
+/******************************************************************************************************************************
+ *  MorseGameMode implementation. See MorseGameMode.h for design notes.
+ *****************************************************************************************************************************/
+
+#include "MorseGameMode.h"
+
+#ifdef CONFIG_DISPLAYWRAPPER
+
+#include <Arduino.h>
+#include <ESP32Encoder.h>
+
+#include "DisplayWrapper.h"
+#include "MorseOutput.h"
+#include "MorsePreferences.h"
+#include "morsedefs.h"
+
+extern ESP32Encoder rotaryEncoder;
+extern const int    PinCLK;
+extern const int    PinDT;
+
+namespace {
+
+  LGFX_Sprite *sprite         = nullptr;
+  bool         lastLeftHanded = false;
+
+  // Restore the Morserino menu's display state. Used both by exit() and by
+  // the failure path of allocate() so that callers see a coherent menu
+  // regardless of whether enter*() succeeded.
+  void restoreMenuDisplay(bool leftHanded) {
+    DisplayWrapper::getLGFX()->setRotation(leftHanded ? 0 : 2);
+    MorseOutput::initDisplay();
+    MorseOutput::setTheme(MorsePreferences::pliste[posTheme].value);
+    pinMode(PinCLK, INPUT_PULLUP);
+    pinMode(PinDT,  INPUT_PULLUP);
+    rotaryEncoder.attachHalfQuad(PinDT, PinCLK);
+    rotaryEncoder.setCount(0);
+  }
+
+  LGFX_Sprite *allocate(int rotation, bool leftHanded) {
+    lastLeftHanded = leftHanded;
+
+    auto *lcd = DisplayWrapper::getLGFX();
+    lcd->setRotation(rotation);
+    lcd->fillScreen(TFT_BLACK);
+
+    // Defensive: if a previous game session somehow left a sprite alive, free
+    // it before allocating again. The normal flow always calls exit() first,
+    // so this should be a no-op in practice.
+    if (sprite) {
+      sprite->deleteSprite();
+      delete sprite;
+      sprite = nullptr;
+    }
+
+    sprite = new LGFX_Sprite(lcd);
+    if (!sprite) {
+      restoreMenuDisplay(leftHanded);
+      return nullptr;
+    }
+    sprite->setPsram(false);
+    sprite->setColorDepth(16);
+    if (!sprite->createSprite(lcd->width(), lcd->height())) {
+      delete sprite;
+      sprite = nullptr;
+      restoreMenuDisplay(leftHanded);
+      return nullptr;
+    }
+    sprite->fillSprite(TFT_BLACK);
+    return sprite;
+  }
+
+} // namespace
+
+LGFX_Sprite *MorseGameMode::enterPortrait(bool leftHanded) {
+  return allocate(leftHanded ? 0 : 2, leftHanded);
+}
+
+LGFX_Sprite *MorseGameMode::enterLandscape(bool leftHanded) {
+  return allocate(leftHanded ? 1 : 3, leftHanded);
+}
+
+void MorseGameMode::pushFrame() {
+  if (!sprite) return;
+  auto *lcd = DisplayWrapper::getLGFX();
+  lcd->startWrite();
+  sprite->pushSprite(lcd, 0, 0);
+  lcd->endWrite();
+}
+
+void MorseGameMode::exit() {
+  // Free the sprite immediately so the heap doesn't carry the ~106 KB
+  // allocation through menu time. This is the change that prevents
+  // fragmentation-driven OOM when starting another game later.
+  if (sprite) {
+    sprite->deleteSprite();
+    delete sprite;
+    sprite = nullptr;
+  }
+  restoreMenuDisplay(lastLeftHanded);
+}
+
+LGFX_Sprite *MorseGameMode::getSprite() {
+  return sprite;
+}
+
+#endif // CONFIG_DISPLAYWRAPPER

--- a/Software/src/Version 6 and newer/MorseGameMode.h
+++ b/Software/src/Version 6 and newer/MorseGameMode.h
@@ -1,0 +1,42 @@
+/******************************************************************************************************************************
+ *  MorseGameMode — owns the off-screen sprite and rotation state used by the M32 Pocket games.
+ *
+ *  Previously these were owned by DisplayWrapper, which kept both a portrait and a landscape sprite
+ *  alive for the device's lifetime — ~106 KB each — leading to OOM when starting Radio Cave after
+ *  Morse Invaders or Fight the Pileup. This module allocates the sprite fresh on game entry and
+ *  frees it on exit, so the heap stays clean during menu time.
+ *
+ *  Only built when CONFIG_DISPLAYWRAPPER is defined (M32 Pocket / TFT boards).
+ *****************************************************************************************************************************/
+
+#pragma once
+
+#ifdef CONFIG_DISPLAYWRAPPER
+
+#include <LovyanGFX.hpp>
+
+namespace MorseGameMode {
+
+  // Allocate a fresh portrait-orientation game sprite (panel-sized).
+  // Sets the panel rotation and clears the screen. Returns the sprite to draw
+  // into, or nullptr on allocation failure (the menu's display state is
+  // automatically restored before nullptr is returned).
+  LGFX_Sprite *enterPortrait(bool leftHanded);
+
+  // Allocate a fresh landscape-orientation game sprite.
+  LGFX_Sprite *enterLandscape(bool leftHanded);
+
+  // Push the sprite to the panel.
+  void pushFrame();
+
+  // Free the sprite and restore the Morserino menu's display state:
+  // portrait rotation, MorseOutput::initDisplay(), theme, and rotary-encoder
+  // pin handoff. Call this once at the end of every game's run().
+  void exit();
+
+  // Currently-allocated sprite, or nullptr if not in game mode.
+  LGFX_Sprite *getSprite();
+
+} // namespace MorseGameMode
+
+#endif // CONFIG_DISPLAYWRAPPER

--- a/Software/src/Version 6 and newer/MorsePileup.cpp
+++ b/Software/src/Version 6 and newer/MorsePileup.cpp
@@ -7,6 +7,7 @@
  *****************************************************************************************************************************/
 
 #include "MorsePileup.h"
+#include "MorseGameMode.h"
 
 bool pileupMode = false;
 String pileupRxText = "";
@@ -352,7 +353,7 @@ static void cwPlayerUpdate() {
 //=== Drawing helpers ===
 
 static void pushFrame() {
-    display.pushGameFrame();
+    MorseGameMode::pushFrame();
 }
 
 static void drawCentredText(int y, const char* text, uint16_t color,
@@ -1576,7 +1577,7 @@ static void stateGameOver() {
 //=== Main entry point ===
 
 void MorsePileup::run() {
-    canvas = display.enterGameMode(MorsePreferences::leftHanded);
+    canvas = MorseGameMode::enterPortrait(MorsePreferences::leftHanded);
     if (!canvas) return;
 
     loadPlayerIdentity();
@@ -1601,16 +1602,7 @@ void MorsePileup::run() {
     cleanupKeyer();
     MorsePreferences::wpm = ftp.wpm;
     MorsePreferences::writePreferences("morserino");
-    display.exitGameMode();
-
-    MorseOutput::initDisplay();
-    #ifdef CONFIG_DISPLAYWRAPPER
-    MorseOutput::setTheme(MorsePreferences::pliste[posTheme].value);
-    #endif
-    pinMode(PinCLK, INPUT_PULLUP);
-    pinMode(PinDT, INPUT_PULLUP);
-    rotaryEncoder.attachHalfQuad(PinDT, PinCLK);
-    rotaryEncoder.setCount(0);
+    MorseGameMode::exit();
     Buttons::modeButton.clicks = 0;
     Buttons::volButton.clicks = 0;
 }

--- a/Software/src/Version 6 and newer/MorseRadioCave.cpp
+++ b/Software/src/Version 6 and newer/MorseRadioCave.cpp
@@ -11,7 +11,7 @@
  *  a final QSO with a remote station — all by keying commands as Morse.
  *
  *  The game runs in landscape orientation on a 320×170 sprite (provided
- *  by DisplayWrapper::enterGameModeLandscape). Twelve rooms, six items,
+ *  by MorseGameMode::enterLandscape). Twelve rooms, six items,
  *  state-dependent room descriptions, CW clues delivered as audio, full
  *  inventory and puzzle logic, victory and death screens, and NVS-backed
  *  save/resume across reboots.
@@ -48,6 +48,7 @@
  *****************************************************************************************************************************/
 
 #include "MorseRadioCave.h"
+#include "MorseGameMode.h"
 
 #ifdef CONFIG_CW_GAME
 
@@ -663,7 +664,7 @@ static bool          cwToneOn      = false;     // true when we're currently sou
 // Drawing helpers
 //=============================================================================
 
-static void pushFrame() { display.pushGameFrame(); }
+static void pushFrame() { MorseGameMode::pushFrame(); }
 
 static void drawCentred(int y, const char* text, uint16_t color,
                         const lgfx::IFont* font = nullptr) {
@@ -2706,27 +2707,10 @@ static void playLoop() {
 //=============================================================================
 
 void MorseRadioCave::run() {
-    canvas = display.enterGameModeLandscape(MorsePreferences::leftHanded);
+    canvas = MorseGameMode::enterLandscape(MorsePreferences::leftHanded);
     if (!canvas) {
-        // Sprite allocation failed. Most common cause: the portrait sprite
-        // from a previous Invaders/Pileup session is still holding ~100 KB
-        // of internal SRAM, leaving no contiguous block for the ~100 KB
-        // landscape sprite. enterGameModeLandscape already changed the
-        // panel rotation before the allocation attempt, so we have to
-        // restore the menu's orientation — otherwise the Morserino menu
-        // ends up displayed rotated 90°.
-        //
-        // Use the same restore sequence as the normal exit path below.
-        DisplayWrapper::getLGFX()->setRotation(MorsePreferences::leftHanded ? 0 : 2);
-        MorseOutput::initDisplay();
-        #ifdef CONFIG_DISPLAYWRAPPER
-        MorseOutput::setTheme(MorsePreferences::pliste[posTheme].value);
-        #endif
-        pinMode(PinCLK, INPUT_PULLUP);
-        pinMode(PinDT,  INPUT_PULLUP);
-        rotaryEncoder.attachHalfQuad(PinDT, PinCLK);
-        rotaryEncoder.setCount(0);
-
+        // Sprite allocation failed. MorseGameMode has already restored the
+        // menu's display state, so all that's left is to tell the user.
         MorseOutput::clearDisplay();
         MorseOutput::printOnScroll(0, BOLD,    0, "Radio Cave");
         MorseOutput::printOnScroll(1, REGULAR, 0, "Out of memory.");
@@ -2755,29 +2739,7 @@ void MorseRadioCave::run() {
     gameMode = false;
     clearPaddleLatches();
 
-    display.exitGameMode();
-
-    // exitGameMode() calls setRotation(3) — that's landscape, correct for
-    // Radio Cave on re-entry but WRONG for the Morserino menu which expects
-    // portrait. When a portrait-mode game (Invaders/Pileup) exits, the
-    // rotation change to 3 coincidentally doesn't matter because... [historical
-    // reason]. Coming out of landscape, the menu stays landscape and looks
-    // 90°-rotated after the first encoder turn.
-    //
-    // Fix: explicitly restore the menu's portrait rotation. The menu uses
-    // rotation 2 normally, or 0 for left-handed users.
-    DisplayWrapper::getLGFX()->setRotation(MorsePreferences::leftHanded ? 0 : 2);
-
-    // Restore normal display for menu (same sequence as MorseGame::run)
-    MorseOutput::initDisplay();
-    #ifdef CONFIG_DISPLAYWRAPPER
-    MorseOutput::setTheme(MorsePreferences::pliste[posTheme].value);
-    #endif
-
-    pinMode(PinCLK, INPUT_PULLUP);
-    pinMode(PinDT,  INPUT_PULLUP);
-    rotaryEncoder.attachHalfQuad(PinDT, PinCLK);
-    rotaryEncoder.setCount(0);
+    MorseGameMode::exit();
 }
 
 #endif  // CONFIG_CW_GAME


### PR DESCRIPTION
## Summary

Move the off-screen game sprite, panel rotation, and rotary-encoder pin handoff out of DisplayWrapper and into a new `MorseGameMode` module owned by the M32 codebase. The change frees the sprite on game **exit** instead of holding it for the device's lifetime, which prevents the heap fragmentation that has been blocking Radio Cave from starting after Invaders or Fight the Pileup.

This is a step toward haklein's broader suggestion of stripping DisplayWrapper back to a thin LGFX shim. DisplayWrapper itself is **not** touched in this PR — its game-mode methods just become unused. They can be removed in a separate follow-up against `oe1wkl/DisplayWrapper`.

## Why

DisplayWrapper kept both sprites — portrait (~106 KB, Invaders/Pileup) and landscape (~106 KB, Radio Cave) — alive for the device's lifetime once allocated. Two problems flowed from that:

1. **Heap fragmentation.** Holding 106 KB across menu sessions fragmented the heap around the persistent allocation. Even after the earlier "free at next entry of other mode" fix, no contiguous 106 KB block was available when Radio Cave's sprite needed to be allocated.
2. **Wrong owner.** The lifetime decision belongs to the application — only the M32 code knows when a game session ends. With DisplayWrapper owning lifetime, the sprite always lingered longer than it needed to.

Giving M32 ownership lets `MorseGameMode::exit()` free the sprite the moment a game session ends. Heap is clean during menu time; the next game's allocation starts from a defragmented baseline.

## What changes

**New module** — `MorseGameMode.h` / `MorseGameMode.cpp`:
- `enterPortrait(leftHanded)` / `enterLandscape(leftHanded)` — allocate sprite + set rotation, return canvas (or `nullptr` on OOM with menu state already restored).
- `pushFrame()` — push current sprite to the panel.
- `exit()` — **free the sprite**, restore menu rotation, call `MorseOutput::initDisplay()`, apply theme, re-attach the rotary encoder. Centralises the post-exit choreography that all three games used to duplicate.

**Game files**:
- `MorseGame::run()`, `MorsePileup::run()`, `MorseRadioCave::run()` — switch from `display.enterGameMode*` / `exitGameMode` / `pushGameFrame` to the `MorseGameMode` equivalents. The duplicated post-exit cleanup collapses into the single `MorseGameMode::exit()` call.
- `MorseRadioCave`'s defensive null-canvas handling shrinks — the module already restored the display, so the game just shows the OOM message and returns.

**DisplayWrapper** — untouched. The game-mode methods become dead code; a separate PR can remove them.

## Diff stats

```
5 files changed, 165 insertions(+), 71 deletions(-)
```

## Test plan

- [ ] Boot → Radio Cave: starts cleanly (regression).
- [ ] Boot → Invaders → exit → Radio Cave: **previously OOM'd, should now start cleanly.** ← the bug this is fixing.
- [ ] Boot → Pileup → exit → Radio Cave: should now start cleanly.
- [ ] Radio Cave → exit → Invaders: works.
- [ ] Repeated back-to-back same-orientation games (Invaders → Pileup → Invaders): works.
- [ ] Long-press exit from any game: menu in correct orientation, no flicker (regression check).
- [ ] Left-handed setting: rotation correct in both portrait and landscape games.
- [ ] Older M32 boards (heltec_wifi_lora_32_V2 etc): unaffected — `MorseGameMode` is `#ifdef CONFIG_DISPLAYWRAPPER` only, and those builds don't enable `CONFIG_CW_GAME` either.

## Follow-up

Once this is verified on hardware:

- New PR against `oe1wkl/DisplayWrapper` to remove the now-unused `enterGameMode*`, `exitGameMode`, `pushGameFrame`, `isInGameMode`, `getGameSprite` methods and the `_gameSprite*` members. That returns DisplayWrapper to a thin shim, per haklein's suggestion.
- Larger follow-up (separate project): drop DisplayWrapper + ThingPulse entirely, have `MorseOutput` use LGFX directly. Touches every board variant — wants its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)