### PR TITLE
Static sprite buffer in BSS (fixes Radio Cave OOM definitively)

### DIFF
--- a/Software/src/Version 6 and newer/MorseGameMode.cpp
+++ b/Software/src/Version 6 and newer/MorseGameMode.cpp
@@ -1,5 +1,30 @@
 /******************************************************************************************************************************
  *  MorseGameMode implementation. See MorseGameMode.h for design notes.
+ *
+ *  Sprite buffer strategy
+ *  ----------------------
+ *  The sprite pixel buffer (~108 KB at 170×320 / 320×170, 16-bit) is a
+ *  static array in BSS, declared at compile time and never touched by the
+ *  heap allocator. Both portrait and landscape game modes share the same
+ *  buffer — they have identical pixel counts on the M32 Pocket panel; only
+ *  the W×H interpretation handed to LGFX differs, and `fillSprite(BLACK)`
+ *  at game entry resets layout state.
+ *
+ *  This is what fixes the Radio-Cave-after-Invaders OOM. Heap-based
+ *  allocation strategies (whether kept-alive or freed-on-exit) all failed
+ *  in practice: a separate persistent ~48 KB allocation made during the
+ *  first game session permanently fragmented the largest contiguous free
+ *  block, leaving it ~2 KB short of what the next 108,800-byte sprite
+ *  needed. Putting the buffer in BSS sidesteps the heap entirely.
+ *
+ *  We use `LGFX_Sprite::setBuffer()` instead of `createSprite()` to hand
+ *  LGFX our static buffer. setBuffer() marks the SpriteBuffer's source as
+ *  Preallocated, which makes its release() skip the heap_free() — so
+ *  ~LGFX_Sprite() is safe and the static buffer is undisturbed across
+ *  game sessions.
+ *
+ *  Trade-off: ~108 KB of internal SRAM (~21% of the chip's 512 KB)
+ *  permanently reserved.
  *****************************************************************************************************************************/
 
 #include "MorseGameMode.h"
@@ -19,6 +44,12 @@ extern const int    PinCLK;
 extern const int    PinDT;
 
 namespace {
+
+  // Static sprite buffer. Lives in BSS — allocated at compile time, never
+  // freed at runtime, immune to heap fragmentation. Sized for the panel's
+  // pixel count at 16-bit colour. Portrait and landscape modes share it;
+  // both have the same total pixel count.
+  alignas(4) uint16_t spriteBuffer[TFT_WIDTH * TFT_HEIGHT];
 
   LGFX_Sprite *sprite         = nullptr;
   bool         lastLeftHanded = false;
@@ -43,11 +74,10 @@ namespace {
     lcd->setRotation(rotation);
     lcd->fillScreen(TFT_BLACK);
 
-    // Defensive: if a previous game session somehow left a sprite alive, free
-    // it before allocating again. The normal flow always calls exit() first,
-    // so this should be a no-op in practice.
+    // Defensive: dispose of any previous sprite wrapper. The static buffer
+    // is shared and remains intact; only the small LGFX_Sprite object is
+    // freed.
     if (sprite) {
-      sprite->deleteSprite();
       delete sprite;
       sprite = nullptr;
     }
@@ -57,14 +87,8 @@ namespace {
       restoreMenuDisplay(leftHanded);
       return nullptr;
     }
-    sprite->setPsram(false);
     sprite->setColorDepth(16);
-    if (!sprite->createSprite(lcd->width(), lcd->height())) {
-      delete sprite;
-      sprite = nullptr;
-      restoreMenuDisplay(leftHanded);
-      return nullptr;
-    }
+    sprite->setBuffer(spriteBuffer, lcd->width(), lcd->height(), 16);
     sprite->fillSprite(TFT_BLACK);
     return sprite;
   }
@@ -88,11 +112,11 @@ void MorseGameMode::pushFrame() {
 }
 
 void MorseGameMode::exit() {
-  // Free the sprite immediately so the heap doesn't carry the ~106 KB
-  // allocation through menu time. This is the change that prevents
-  // fragmentation-driven OOM when starting another game later.
+  // Dispose of the small LGFX_Sprite wrapper. The underlying buffer is
+  // Preallocated (static), so SpriteBuffer::release() inside ~LGFX_Sprite()
+  // skips the heap_free(), leaving the static buffer untouched and ready
+  // for the next game session.
   if (sprite) {
-    sprite->deleteSprite();
     delete sprite;
     sprite = nullptr;
   }


### PR DESCRIPTION
## Summary

Final fix for the Radio-Cave-after-Invaders/Pileup OOM. Moves the game-mode sprite pixel buffer out of the heap and into a static BSS array — immune to fragmentation, shared between portrait and landscape modes.

## Why the earlier fixes weren't enough

[#149](https://github.com/oe1wkl/Morserino-32/pull/149) made `MorseGameMode::exit()` free the sprite immediately on game exit, hoping to keep the heap clean during menu time. On the bench, the OOM persisted.

A diagnostic build (heap stats logged at every game enter/exit) revealed the actual cause:

```
boot/menu (clean):              free=168,400  largest=155,636
after one Invaders session:     free=168,012  largest=106,484
                                              ^^^ -49,152 (-48 KB)
```

Total free heap recovered (388-byte residue is noise). But the **largest contiguous block** permanently shrank by exactly 48 KB. Some other persistent allocation made during the first game session — almost certainly from the sidetone / I2S audio init — ended up inside what had been the largest free region, splitting it. After the sprite was freed, the freed 108 KB hole couldn't merge across the obstruction. The remaining largest block (106,484 bytes) is just **2,316 bytes short** of what the next 108,800-byte sprite needs.

No heap-allocation strategy can recover those 2 KB. The obstruction is permanent and not under our control.

## The fix

```cpp
alignas(4) uint16_t spriteBuffer[TFT_WIDTH * TFT_HEIGHT];   // BSS
…
sprite->setBuffer(spriteBuffer, lcd->width(), lcd->height(), 16);
```

LGFX has a `setBuffer()` API that accepts an external buffer and marks the underlying `SpriteBuffer` as `Preallocated` — `release()` then skips the `heap_free()`, so `~LGFX_Sprite()` is safe and the static buffer is never disturbed. Both portrait (170×320) and landscape (320×170) modes share the buffer; both have the same pixel count, and `fillSprite(BLACK)` at game entry resets layout state.

## Verification

Heap diagnostics on the `heap-diagnostics` branch confirm `largest_contiguous_block` stays **flat** at ~49,140 across all game sessions — no fragmentation. Only a small ~360-byte LGFX_Sprite wrapper object jiggles in and out of the heap on enter/exit.

Tested on hardware: Boot → Invaders → exit → Radio Cave starts cleanly. Repeated Invaders ↔ Radio Cave cycles work. Long-press exits work. Menu rotation correct.

## Cost

~108 KB of internal SRAM is now permanently reserved (`TFT_WIDTH × TFT_HEIGHT × 2`). On the M32 Pocket's 512 KB of internal SRAM that's ~21% — acceptable for a fixed-purpose firmware. Free heap during gameplay is comparable to the post-[#149](https://github.com/oe1wkl/Morserino-32/pull/149) state (the buffer was always allocated during games then too, just on the heap); free heap during menu time is ~108 KB lower than before the games were added.

## Diff

One file, +39 / −15 lines. No API changes — `MorseGameMode` keeps the same public interface introduced in [#149](https://github.com/oe1wkl/Morserino-32/pull/149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)