### PR TITLE
Fix battery-icon background gap after full display clear

### DIFF
--- a/Software/src/Version 6 and newer/MorseOutput.cpp
+++ b/Software/src/Version 6 and newer/MorseOutput.cpp
@@ -1268,9 +1268,15 @@ void MorseOutput::drawBatteryIcon(uint8_t pps, uint8_t bars) {
     const int bodyW = 26, iconH = 16, nubW = 4, nubH = 8, pad = 2, margin = 2;
     int ix = display.getWidth() - bodyW - nubW - margin;
     int iy = (SCROLL_TOP - iconH) / 2;
-    // Clear icon area with status line background colour
+    // Paint the FULL status-line-height column behind the icon with the
+    // status-line background colour. clearStatusLine skips this 34-px
+    // column when the icon is visible (to avoid overdrawing the icon),
+    // so we have to fill the full column ourselves — otherwise the
+    // strips above and below the icon end up showing whatever was
+    // there before (e.g. the blue background painted by display.clear()
+    // on game exit), creating a visible gap.
     display.setColor(WHITE);
-    display.fillRect(ix - 1, iy, bodyW + nubW + 3, iconH + 1);
+    display.fillRect(display.getWidth() - 34, 0, 34, SCROLL_TOP);
 
     // Draw in status line text colour
     display.setColor(BLACK);


### PR DESCRIPTION
## Summary

Small cosmetic fix unrelated to the OOM/heap saga — the orange status-line highlight was breaking up around the battery icon after exiting a game (or any path that ran a full \`display.clear()\`).

## Cause

\`clearStatusLine\` deliberately skips the right-most 34-px column when the battery icon is visible, to avoid overdrawing the icon and causing flicker. But \`drawBatteryIcon\` only painted the icon's bounding rect (33×17 px) orange — the strips above and below the icon (within the 34-px column) were never repainted with the status-line background. Those strips showed whatever was painted there last; after a full \`display.clear()\` they showed blue and stayed blue forever.

## Fix

\`drawBatteryIcon\` now paints the FULL status-line-height column (right-most 34 px × \`SCROLL_TOP\` rows) with the status-line background, then draws the icon body on top. That fully complements \`clearStatusLine\`'s skip-the-icon-area optimisation — the entire status line ends up orange regardless of what was painted there before.

Localised to \`drawBatteryIcon\`. \`clearStatusLine\` and the icon-state tracking are unchanged.

## Test plan

- [ ] Boot → splash → menu: battery icon area shows solid orange across the status line. (No regression.)
- [ ] Boot → enter Fight Pileup / Morse Invaders / Radio Cave → exit: returning menu shows solid orange across the status line, no blue strips around the battery icon.
- [ ] Same after Echo Trainer, Decoder, etc. (any mode that runs \`display.clear()\` on entry/exit).
- [ ] OLED boards: \`drawBatteryIcon\` is gated on \`CONFIG_MCP73871\` (which OLED boards don't define), so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)