### PR TITLE
Fix multipart file player resume position

### DIFF
--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -1929,12 +1929,13 @@ void MorsePreferences::scanFileParts() {
                     fileParts[partCount - 1].endOffset = lineStart;
                 }
                 
-                // Record this part
+                // Record this part. Preserve wordPointer — that is playback
+                // state (loaded from NVS at boot, updated during play), not
+                // file structure. The upload path resets it explicitly.
                 FilePart& part = fileParts[partCount];
                 // startOffset = position AFTER the separator line
                 part.startOffset = f.position();   // current position is right after this line
                 part.endOffset = fileSize;          // will be updated when next separator is found
-                part.wordPointer = 0;
                 
                 // Copy chapter name
                 int nameLen = lineLen - pos;

--- a/Software/src/Version 6 and newer/MorseWiFi.cpp
+++ b/Software/src/Version 6 and newer/MorseWiFi.cpp
@@ -696,6 +696,9 @@ void internal::handleFileUpload(){ // upload a new file to the SPIFFS
         MorsePreferences::fileWordPointer = 0;                         // reset word counter for file player
 //DEBUG("fileWordPointer @ file upload: " + String(MorsePreferences::fileWordPointer));
         MorsePreferences::writeWordPointer();
+        // Fresh file invalidates prior progress in every chapter
+        for (int i = 0; i < MAX_FILE_PARTS; i++)
+          MorsePreferences::fileParts[i].wordPointer = 0;
         MorsePreferences::scanFileParts();          // ADD: detect multipart
         MorsePreferences::writeFilePartData();      // ADD: persist to NVS
 //DEBUG("handleFileUpload Size: " + String(upload.totalSize));

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -3936,10 +3936,15 @@ void m32Put(String type, String token, String value) {                    /// PU
         if (uploadActive) {
           String name = String(uploadFile.path());   // ← was uploadFile.name()
           uploadFile.close();
+          // If we uploaded player.txt, reset all per-part word pointers
+          // before scanning — a fresh file invalidates prior progress.
+          if (name == "/player.txt" || name == "player.txt") {
+            for (int i = 0; i < MAX_FILE_PARTS; i++)
+              MorsePreferences::fileParts[i].wordPointer = 0;
+          }
           MorsePreferences::scanFileParts();
           MorsePreferences::writeFilePartData();
           uploadActive = false;
-          // If we uploaded player.txt, reset the word pointer
           if (name == "/player.txt" || name == "player.txt") {
             MorsePreferences::fileWordPointer = 0;
             MorsePreferences::writeWordPointer();


### PR DESCRIPTION
## Summary

Fixes a bug in the multipart file player where the resume position within a chapter was being wiped on every player start, so playback always restarted from the beginning of the selected part.

## What was happening

1. Boot: `readFilePartData()` correctly loaded saved per-part word pointers from NVS into `fileParts[i].wordPointer`.
2. User opens File Player: `scanFileParts()` ran and unconditionally set `part.wordPointer = 0` for every detected part, wiping the in-RAM state.
3. User picks a chapter: `writeFilePartData()` persisted the now-zeroed pointers back to NVS, destroying the saved progress on flash as well.
4. Playback used `wcount = fileParts[partChoice].wordPointer` (== 0) and started from the beginning.

So although `writeWordPointer()` correctly *saved* the stop position when the player exited, the very next player start scrubbed it.

## Fix

`scanFileParts()` is meant to scan file *structure* (start/end offsets, chapter names). Word pointers are *playback state* and shouldn't be touched there.

- `MorsePreferences.cpp`: remove `part.wordPointer = 0;` from `scanFileParts()`.
- `m32_v6.ino` (chunked m32-protocol upload) and `MorseWiFi.cpp` (HTTP upload): explicitly zero all `fileParts[i].wordPointer` before calling `scanFileParts()`/`writeFilePartData()`. A fresh upload still resets every chapter to 0.

## Test plan

- [ ] Upload a multipart `player.txt`, play a few words in a chapter, exit to menu, restart File Player, pick the same chapter → playback resumes near where it stopped (not at chapter start).
- [ ] Repeat across a power cycle — saved position should persist via NVS.
- [ ] Upload a new `player.txt` (both via m32 protocol and via the WiFi HTTP form) → all chapters start from word 0.
- [ ] Single-part (non-multipart) file player still resumes as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)