### PR TITLE
Menu UX and post-WiFi game stability fixes

### DIFF
--- a/Software/src/Version 6 and newer/MorseGameMode.cpp
+++ b/Software/src/Version 6 and newer/MorseGameMode.cpp
@@ -37,6 +37,7 @@
 extern ESP32Encoder rotaryEncoder;
 extern const int    PinCLK;
 extern const int    PinDT;
+extern int          checkEncoder();
 
 // RTC-resident state for the memory-clearing reboot path. Defined in
 // m32_v6.ino; we set them and call ESP.restart() if sprite allocation
@@ -46,13 +47,18 @@ extern uint32_t rebootMagic;
 extern uint8_t  rebootMenuPtr;
 
 // Pixels removed from the long side of the panel when sizing the sprite.
-// At 170×320, trimming 16 from the long side gives a 170×304 / 304×170
-// sprite (= 103,360 bytes), comfortably under the ~106 KB largest free
-// block we observe after one game session. Decrease this only after
-// re-running the heap diagnostics on the heap-diagnostics branch and
-// confirming there's enough headroom.
+// At 170×320, trimming 28 from the long side gives a 170×292 / 292×170
+// sprite (= 99,280 bytes), ~4 KB smaller than the 16-px-trim version.
+// Bumped from 16 to 28 to leave a comfortable margin between the sprite
+// and the largest free contiguous heap block after a setupESPNow /
+// setupWifi cycle. Heap probes measured (free / largest contiguous):
+//   clean boot     163 KB / 106 KB    sprite + 7 KB margin
+//   after WiFi     120 KB / 106 KB    sprite + 7 KB margin
+//   after ESP-NOW  113 KB / 102 KB    sprite + 3 KB margin
+// Decrease only after re-running the heap diagnostics and confirming
+// there's still headroom.
 #ifndef MORSE_GAMEMODE_SPRITE_TRIM
-#define MORSE_GAMEMODE_SPRITE_TRIM 16
+#define MORSE_GAMEMODE_SPRITE_TRIM 28
 #endif
 
 namespace {
@@ -71,6 +77,11 @@ namespace {
     pinMode(PinDT,  INPUT_PULLUP);
     rotaryEncoder.attachHalfQuad(PinDT, PinCLK);
     rotaryEncoder.setCount(0);
+    // Resync checkEncoder()'s static oldPosition: setCount(0) zeroes the
+    // hardware, but the cached old position is whatever it was during the
+    // game. Without this, the menu's first checkEncoder() call after game
+    // exit sees a phantom step and shifts the cursor to a neighbour game.
+    (void) checkEncoder();
   }
 
   LGFX_Sprite *allocate(int rotation, bool leftHanded) {

--- a/Software/src/Version 6 and newer/MorseMenu.cpp
+++ b/Software/src/Version 6 and newer/MorseMenu.cpp
@@ -674,7 +674,15 @@ boolean MorseMenu::menuExec() {       // return true if we should  leave menu af
                 clearPaddleLatches();
                 goto setupDecoder;
 #ifdef CONFIG_CW_GAME
+      // After a WiFi/ESP-NOW session, the QuickEspNow library leaves
+      // callbacks and tasks behind that can fire during game play and
+      // corrupt unrelated state — see the comment on
+      // rebootIfWifiAlreadyUsed() above. Heap probes confirm this is
+      // not a memory-shortage issue (heap is fully restored before the
+      // game starts), so the only safe recovery is a clean reboot that
+      // auto-resumes into the same menu item.
       case _morseInvaders:
+                rebootIfWifiAlreadyUsed();
                 MorseGame::run();
                 m32state = menu_loop;
                 // Clear both buttons: a long-press exit leaves clicks == -1, which
@@ -683,18 +691,21 @@ boolean MorseMenu::menuExec() {       // return true if we should  leave menu af
                 Buttons::volButton.clicks  = 0;
                 return false;
       case _fightPileup:
+                rebootIfWifiAlreadyUsed();
                 MorsePileup::run();
                 m32state = menu_loop;
                 Buttons::modeButton.clicks = 0;
                 Buttons::volButton.clicks  = 0;
                 return false;
       case _radioCave:
+                rebootIfWifiAlreadyUsed();
                 MorseRadioCave::run();
                 m32state = menu_loop;
                 Buttons::modeButton.clicks = 0;
                 Buttons::volButton.clicks  = 0;
                 return false;
       case _morsel:
+                rebootIfWifiAlreadyUsed();
                 MorseMorsel::run();
                 m32state = menu_loop;
                 Buttons::modeButton.clicks = 0;

--- a/Software/src/Version 6 and newer/MorseOutput.cpp
+++ b/Software/src/Version 6 and newer/MorseOutput.cpp
@@ -606,6 +606,33 @@ const int  dutyCycleZero = 0;
 
 ////// Display functions
 
+// Idempotency cache for the very common "clearStatusLine() followed by
+// printOnStatusLine(true, 0, str)" pattern used by the main menu and the
+// preferences menu on every encoder click. Without this, the white flash
+// between the clear and the reprint is visible as a flicker. We defer the
+// actual clear until the next printOnStatusLine call: if it would
+// reproduce the currently-visible text at xpos=0, we skip both ops.
+namespace {
+    bool   statusClearPending = false;   // clearStatusLine was called, not yet flushed
+    String statusLineCache;              // text last drawn via printOnStatusLine at xpos=0
+    bool   statusLineStrong  = false;    // strong flag for that cached text
+
+    // Paint the full-width white background, respecting the battery icon's
+    // right-side reserved area. Extracted so clearStatusLine() and the
+    // deferred-clear path inside printOnStatusLine() stay in sync.
+    void paintStatusBackground() {
+        display.setFont(DialogInput_plain_12);
+        display.setColor(WHITE);
+#ifdef CONFIG_MCP73871
+        if (MorseOutput::batteryIconVisible)
+            display.fillRect(0, 0, display.getWidth() - 34, SCROLL_TOP);
+        else
+#endif
+            display.fillRect(0, 0, display.getWidth(), SCROLL_TOP);
+        display.setColor(BLACK);
+    }
+}
+
 void MorseOutput::initDisplay()
 {
 #ifdef OLED_RST
@@ -622,6 +649,11 @@ void MorseOutput::initDisplay()
 #endif
     display.flipScreenVertically();
   display.clear();
+  // Screen was just wiped (e.g. by MorseGameMode::exit reinitialising the
+  // panel after a game). Drop any cached status-line state so the next
+  // printOnStatusLine actually repaints rather than short-circuiting.
+  statusClearPending = true;
+  statusLineCache    = "";
 }
 
 
@@ -638,6 +670,11 @@ void MorseOutput::setTheme (uint8_t theme) {
 void MorseOutput::clearDisplay() {
     display.clear();
     display.display();
+    // Whole screen was wiped; the status-line cache no longer reflects
+    // what's on screen. Force the next printOnStatusLine to repaint its
+    // full background by treating it as if clearStatusLine was just called.
+    statusClearPending = true;
+    statusLineCache    = "";
 #ifdef CONFIG_MCP73871
     batteryDisplayDirty = true;
     batteryIconVisible = false;
@@ -1428,7 +1465,21 @@ void MorseOutput::dispM32Logo() {
 
 
 void MorseOutput::printOnStatusLine(boolean strong, uint8_t xpos, const String& string) {    // place a string onto the status line; chars are 7px wide = 18 chars per line
-  //DEBUG ("LINE_HEIGHT: " + LINE_HEIGHT);
+  // Fast path: deferred clear + identical full-line text → already on
+  // screen, skip both operations entirely.
+  if (xpos == 0 && statusClearPending &&
+      statusLineCache == string && statusLineStrong == strong) {
+    statusClearPending = false;
+    resetTOT();
+    return;
+  }
+
+  // Honour any pending clearStatusLine before drawing.
+  if (statusClearPending) {
+    paintStatusBackground();
+    statusClearPending = false;
+  }
+
   if (strong)
     display.setFont(DialogInput_bold_12);
   else
@@ -1441,6 +1492,17 @@ void MorseOutput::printOnStatusLine(boolean strong, uint8_t xpos, const String& 
   display.drawString(xpos * display.getStringWidth("A"), 0, string);
   display.setColor(WHITE);
   display.display();
+
+  // Only full-line writes (xpos==0) become the cached value; partial
+  // updates (WPM digits, keyer mode, etc.) invalidate the cache since
+  // the visible text is no longer a single known string.
+  if (xpos == 0) {
+    statusLineCache  = string;
+    statusLineStrong = strong;
+  } else {
+    statusLineCache = "";
+  }
+
   resetTOT();
   #ifdef CONFIG_MCP73871
   //  batteryDisplayDirty = true;    // redraw icon on next updateBatteryDisplay
@@ -1450,16 +1512,11 @@ void MorseOutput::printOnStatusLine(boolean strong, uint8_t xpos, const String& 
 
 
 void MorseOutput::clearStatusLine() {
-    display.setFont(DialogInput_plain_12);
-    display.setColor(WHITE);
-#ifdef CONFIG_MCP73871
-    if (batteryIconVisible)
-        display.fillRect(0, 0, display.getWidth() - 34, SCROLL_TOP);
-    else
-#endif
-        display.fillRect(0, 0, display.getWidth(), SCROLL_TOP);
-    display.setColor(BLACK);
-    display.display();
+    // Defer the actual paint to the next printOnStatusLine. If that call
+    // reprints the same text, both ops collapse to a no-op (no flicker).
+    // All in-tree clearStatusLine callers immediately follow with a
+    // printOnStatusLine, so the deferral is always honoured.
+    statusClearPending = true;
 }
 
 /// clear all visible lines of the scroll area


### PR DESCRIPTION
## Summary

Four small, independent fixes that together make the TFT menu/game flow robust and pleasant on the M32 Pocket. All validated on hardware with heap probes captured before/after WiFi/ESP-NOW and sprite cycles.

- **Encoder cursor returns to the game just exited.** `MorseGameMode::exit()` calls `rotaryEncoder.setCount(0)`, but `checkEncoder()`'s static `oldPosition` still held the in-game value — the menu's first encoder poll then saw a phantom step and shifted to a neighbour game. Resync by consuming one `checkEncoder()` call right after `setCount(0)`.
- **Status-line flicker on every encoder turn is gone.** Menu and preferences called `clearStatusLine()` + `printOnStatusLine()` per redraw; on the auto-flushing LovyanGFX wrappers the intermediate all-white state is visible. `clearStatusLine()` now defers, and identical full-line reprints short-circuit. `clearDisplay`/`initDisplay` invalidate the cache so transitions (game exit, prefs entry) repaint the full white background.
- **Sprite trim 16 → 28 px** (`MORSE_GAMEMODE_SPRITE_TRIM`). Sprite drops from ~103 KB to ~99 KB, leaving ~7 KB margin against the largest free contiguous block after WiFi (106 KB) and ~3 KB after ESP-NOW (102 KB). Trade-off is a slightly wider black strip on the long edge of TFT games.
- **Trigger memory-clearing reboot before TFT games when WiFi was used.** `rebootIfWifiAlreadyUsed()` already covered re-entry into WiFi-using modes; extend it to all four TFT games. Heap probes confirmed the game's heap is fine when launched after WiFi/ESP-NOW, but the game then crashes mid-play from dangling QuickEspNow callbacks. With the guard, the device reboots first and auto-resumes into a clean state.

## Heap measurements (M32 Pocket, pocketwroom, trim=28)

| Scenario | Free | Largest contig | Sprite margin |
|---|---:|---:|---:|
| Clean boot | 163 KB | 106 KB | +7 KB |
| After setupWifi (full WiFi) | 120 KB | 106 KB | +7 KB |
| After setupESPNow | 113 KB | 102 KB | +3 KB |
| After any WiFi → game (with guard) | reboot → 163 KB / 106 KB | +7 KB |

## Test plan

- [x] M32 Pocket: encoder cursor returns to selected game after exit (Invaders, Pileup, RadioCave, Morsel)
- [x] M32 Pocket: no flicker on `Select Mode:` or preferences top line on encoder turns
- [x] M32 Pocket: status line repaints correctly after game exit (full white background, not just text width)
- [x] M32 Pocket: Morse Invaders after Transceiver → WiFi Trx → exit no longer crashes (now triggers reboot + resume)
- [x] M32 Pocket: Morse Invaders after Generator (ESP-NOW) → exit no longer crashes (same)
- [x] Builds clean on `pocketwroom` and `heltec_wifi_lora_32_V2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)