### PR TITLE
Auto-clean stale .ino N.cpp duplicates before each build

### DIFF
--- a/.github/workflows/pio-ci.yml
+++ b/.github/workflows/pio-ci.yml
@@ -21,4 +21,9 @@ jobs:
         run: pip install --upgrade platformio
 
       - name: Build PlatformIO
-        run: pio ci Software/src/Version\ 6\ and\ newer -c Software/src/platformio.ini -e heltec_wifi_lora_32_V2
+        # Use `pio run -d <project_dir>` rather than `pio ci`. `pio ci`
+        # copies sources to a temporary directory and builds there, which
+        # breaks `extra_scripts` paths that reference files in the real
+        # project tree (the script isn't copied). `pio run` builds in
+        # place and matches what developers run locally.
+        run: pio run -d Software/src -e heltec_wifi_lora_32_V2

--- a/Software/src/platformio.ini
+++ b/Software/src/platformio.ini
@@ -12,6 +12,14 @@
 src_dir=Version 6 and newer
 default_envs = pocketwroom
 
+[env]
+; Base section inherited by every [env:*]. Used to attach a pre-build
+; hook that auto-removes any `<sketch>.ino N.cpp` duplicates left in the
+; source tree by interrupted builds or Finder/iCloud copies — these
+; otherwise cause "multiple definition" linker errors. See
+; scripts/clean_ino_dupes.py for details.
+extra_scripts = pre:scripts/clean_ino_dupes.py
+
 [common]
 lib_deps_external =
 	bblanchon/ArduinoJson@6.20.1

--- a/Software/src/scripts/clean_ino_dupes.py
+++ b/Software/src/scripts/clean_ino_dupes.py
@@ -1,0 +1,57 @@
+"""
+PlatformIO pre-build hook: delete stale `<sketch>.ino N.cpp` duplicates.
+
+Background
+----------
+PlatformIO converts `.ino` sketches into `.cpp` translation units as part
+of the build. If a build is interrupted (Ctrl-C, IDE crash, USB
+disconnect at the wrong moment) or if Finder/iCloud creates duplicates
+of the .ino source, the source tree can be left with files like:
+
+    Version 6 and newer/m32_v6.ino 2.cpp
+    Version 6 and newer/m32_v6.ino 3.cpp
+
+PIO then compiles both the canonical `m32_v6.ino.cpp` and the duplicates,
+producing "multiple definition of …" linker errors for every symbol in
+the sketch. The cure has always been a manual `rm` — this script makes
+the cleanup automatic so a hand-fix is never needed again.
+
+Pattern matched: any file whose name is `<anything>.ino <digits>.cpp` or
+`<anything>.ino <digits>` (a Finder duplicate that has yet to be
+re-extensioned). The space between `.ino` and the digit is what
+distinguishes a Finder/PIO duplicate from a legitimate `.cpp` file.
+
+Scope: limited to the project's `src_dir` (the directory PIO compiles
+from). Other parts of the tree are untouched.
+"""
+
+import os
+import re
+from pathlib import Path
+
+# Injected by PlatformIO at script load time.
+Import("env")  # noqa: F821 - PIO injects this builtin
+
+# Filenames like:   m32_v6.ino 2.cpp     m32_v6.ino 10.cpp     foo.ino 3
+# But NOT:          m32_v6.ino.cpp       m32_v6_2.cpp          m32_v6 2.cpp
+_DUPE_RE = re.compile(r".+\.ino \d+(\.cpp)?$")
+
+
+def _clean(src_dir: str) -> int:
+    """Remove any duplicate-pattern files under ``src_dir``. Returns count."""
+    removed = 0
+    for dirpath, _dirnames, filenames in os.walk(src_dir):
+        for name in filenames:
+            if _DUPE_RE.match(name):
+                target = Path(dirpath) / name
+                try:
+                    target.unlink()
+                    print(f"[clean_ino_dupes] removed stale duplicate: {target}")
+                    removed += 1
+                except OSError as exc:  # pragma: no cover - defensive
+                    print(f"[clean_ino_dupes] could not remove {target}: {exc}")
+    return removed
+
+
+src_dir = env.subst("$PROJECT_SRC_DIR")  # noqa: F821
+_clean(src_dir)


### PR DESCRIPTION
## Summary

Interrupted PlatformIO builds (Ctrl-C, IDE crash, USB disconnect at the wrong moment) and Finder/iCloud duplication occasionally leave files like `m32_v6.ino 2.cpp`, `m32_v6.ino 3.cpp` in the source tree. PIO then compiles both the canonical sketch and the duplicates, breaking the link with dozens of "multiple definition of …" errors. The cure has always been a manual `rm` — this hit twice in a single session recently.

Add a small PIO pre-build hook (`scripts/clean_ino_dupes.py`) that scans `$PROJECT_SRC_DIR` for any file matching `<basename>.ino <digits>(.cpp)?` and deletes it before the build starts. Hooked via an `[env]` base section in `platformio.ini` so every env inherits it automatically — no per-env wiring needed.

The match pattern is deliberately narrow: only files where a literal space precedes the digit (which is exactly what Finder/PIO produce as duplicates). Normal source files like `m32_v6.ino`, `m32_v6.ino.cpp`, and `m32_v6_2.cpp` are not touched.

## Test plan

- [x] Plant `m32_v6.ino 2.cpp` + `m32_v6.ino 7.cpp` → run pocketwroom build → both removed, build succeeds, removal announced on stdout
- [x] Plant `m32_v6.ino 3.cpp` → run heltec_wifi_lora_32_V2 build → removed, build succeeds
- [x] Hook adds zero build-time overhead on a clean tree (just walks `src_dir` once)

🤖 Generated with [Claude Code](https://claude.com/claude-code)