### PR TITLE
8-bpp palette sprite for Morsel, Pileup, Radio Cave (Stage 1)

### DIFF
--- a/Software/src/Version 6 and newer/GamePalette.h
+++ b/Software/src/Version 6 and newer/GamePalette.h
@@ -1,0 +1,46 @@
+/******************************************************************************************************************************
+ *  GamePalette — shared 8-bpp colour palette for the M32 Pocket game sprite.
+ *
+ *  Games that use an 8-bpp (palette) game sprite refer to colours by the
+ *  indices in GamePaletteIndex below. MorseGameMode populates the sprite's
+ *  palette from the matching RGB565 table (kGamePalette[] in
+ *  MorseGameMode.cpp) — the enum order and that table MUST stay in sync.
+ *
+ *  Why indexed colour
+ *  ------------------
+ *  An 8-bpp sprite is half the size of the 16-bpp one (~50 KB vs ~99 KB at
+ *  the current trim), which removes the heap pressure that previously made
+ *  the sprite and WiFi/ESP-NOW compete for the same large contiguous block.
+ *
+ *  LovyanGFX's 8-bpp mode is *pure* indexed colour: the colour argument to
+ *  any drawing call is masked to its low byte and used directly as a
+ *  palette index (there is no nearest-colour matching). So drawing calls on
+ *  an 8-bpp sprite must pass these PAL_* indices, never RGB565 values. The
+ *  palette entries hold the exact RGB565 values the games used before, so
+ *  the on-screen result is pixel-identical to the old 16-bpp sprite.
+ *****************************************************************************************************************************/
+
+#pragma once
+
+#ifdef CONFIG_TFT
+
+#include <cstdint>
+
+enum GamePaletteIndex : uint8_t {
+  PAL_BLACK = 0,    // 0x0000  true black (sprite clear / LCD letterbox match)
+  PAL_BG,           // 0x0841  dark near-black background
+  PAL_WHITE,        // 0xFFFF  body / HUD text
+  PAL_RED,          // 0xF800  red — warnings, lives, danger, wrong letter
+  PAL_CYAN,         // 0x07FF  cyan — accents, headings, score
+  PAL_YELLOW,       // 0xFFE0  yellow — highlights, titles, level-up
+  PAL_GREEN,        // 0x07E0  green — success / OK / correct
+  PAL_GREY,         // 0x7BEF  mid grey — dim text, miss
+  PAL_LIGHTGREY,    // 0xBDF7  light grey — secondary text / hints
+  PAL_MIDBLUE,      // 0x528A  mid-blue — frames, revealed-wrong slot
+  PAL_BLUE,         // 0x001F  blue — input text
+  PAL_MAGENTA,      // 0xF81F  magenta — attack prompt
+  PAL_DARKGREY,     // 0x2104  dark grey — status/footer band
+  PAL_COUNT         // number of palette entries in use
+};
+
+#endif // CONFIG_TFT

--- a/Software/src/Version 6 and newer/MorseGameMode.cpp
+++ b/Software/src/Version 6 and newer/MorseGameMode.cpp
@@ -33,6 +33,7 @@
 #include "MorseOutput.h"
 #include "MorsePreferences.h"
 #include "morsedefs.h"
+#include "GamePalette.h"
 
 extern ESP32Encoder rotaryEncoder;
 extern const int    PinCLK;
@@ -66,6 +67,24 @@ namespace {
   LGFX_Sprite *sprite         = nullptr;
   bool         lastLeftHanded = false;
 
+  // RGB565 colour for each GamePaletteIndex. Order MUST match the enum in
+  // GamePalette.h. Loaded into an 8-bpp sprite's palette by allocate().
+  const uint16_t kGamePalette[PAL_COUNT] = {
+    0x0000,  // PAL_BLACK
+    0x0841,  // PAL_BG
+    0xFFFF,  // PAL_WHITE
+    0xF800,  // PAL_RED
+    0x07FF,  // PAL_CYAN
+    0xFFE0,  // PAL_YELLOW
+    0x07E0,  // PAL_GREEN
+    0x7BEF,  // PAL_GREY
+    0xBDF7,  // PAL_LIGHTGREY
+    0x528A,  // PAL_MIDBLUE
+    0x001F,  // PAL_BLUE
+    0xF81F,  // PAL_MAGENTA
+    0x2104,  // PAL_DARKGREY
+  };
+
   // Restore the Morserino menu's display state. Used both by exit() and by
   // the failure path of allocate() so that callers see a coherent menu
   // regardless of whether enter*() succeeded.
@@ -84,7 +103,7 @@ namespace {
     (void) checkEncoder();
   }
 
-  LGFX_Sprite *allocate(int rotation, bool leftHanded) {
+  LGFX_Sprite *allocate(int rotation, bool leftHanded, uint8_t colorDepth) {
     lastLeftHanded = leftHanded;
 
     auto *lcd = (&display);
@@ -115,7 +134,7 @@ namespace {
       MorseGameMode::triggerMemoryClearingReboot();
     }
     sprite->setPsram(false);
-    sprite->setColorDepth(16);
+    sprite->setColorDepth(colorDepth == 8 ? 8 : 16);
     if (!sprite->createSprite(spriteW, spriteH)) {
       // Sprite buffer allocation failed — heap is fragmented (typically
       // after a WiFi Trx session). Reboot to clear, then resume directly
@@ -124,7 +143,17 @@ namespace {
       sprite = nullptr;
       MorseGameMode::triggerMemoryClearingReboot();
     }
-    sprite->fillSprite(TFT_BLACK);
+    if (colorDepth == 8) {
+      // Load the shared game palette. createSprite() auto-creates a default
+      // grayscale palette for 8-bpp; this replaces it (create_palette frees
+      // the old one first, so no leak). PAL_BLACK is index 0, so a sprite
+      // cleared to index 0 reads as true black — consistent with the
+      // TFT_BLACK clear used by the 16-bpp path.
+      sprite->createPalette(kGamePalette, PAL_COUNT);
+      sprite->fillSprite(PAL_BLACK);
+    } else {
+      sprite->fillSprite(TFT_BLACK);
+    }
     return sprite;
   }
 
@@ -148,12 +177,12 @@ void MorseGameMode::warmup() {
   tmp.deleteSprite();
 }
 
-LGFX_Sprite *MorseGameMode::enterPortrait(bool leftHanded) {
-  return allocate(leftHanded ? 0 : 2, leftHanded);
+LGFX_Sprite *MorseGameMode::enterPortrait(bool leftHanded, uint8_t colorDepth) {
+  return allocate(leftHanded ? 0 : 2, leftHanded, colorDepth);
 }
 
-LGFX_Sprite *MorseGameMode::enterLandscape(bool leftHanded) {
-  return allocate(leftHanded ? 1 : 3, leftHanded);
+LGFX_Sprite *MorseGameMode::enterLandscape(bool leftHanded, uint8_t colorDepth) {
+  return allocate(leftHanded ? 1 : 3, leftHanded, colorDepth);
 }
 
 void MorseGameMode::pushFrame() {

--- a/Software/src/Version 6 and newer/MorseGameMode.h
+++ b/Software/src/Version 6 and newer/MorseGameMode.h
@@ -36,11 +36,16 @@ namespace MorseGameMode {
   // setup() then auto-resumes into the same menu item with a defragmented
   // heap. Callers may still keep a defensive `if (!canvas) return;` for
   // robustness, but it should never fire.
-  LGFX_Sprite *enterPortrait(bool leftHanded);
+  //
+  // colorDepth selects the sprite's bits-per-pixel: 16 (RGB565, the
+  // default) or 8 (indexed palette — see GamePalette.h). An 8-bpp sprite
+  // is half the size; games that opt in must draw using PAL_* palette
+  // indices instead of RGB565 values.
+  LGFX_Sprite *enterPortrait(bool leftHanded, uint8_t colorDepth = 16);
 
   // Allocate a fresh landscape-orientation game sprite. Same semantics as
   // enterPortrait — reboots on allocation failure.
-  LGFX_Sprite *enterLandscape(bool leftHanded);
+  LGFX_Sprite *enterLandscape(bool leftHanded, uint8_t colorDepth = 16);
 
   // Push the sprite to the panel.
   void pushFrame();

--- a/Software/src/Version 6 and newer/MorseMorsel.cpp
+++ b/Software/src/Version 6 and newer/MorseMorsel.cpp
@@ -1007,7 +1007,7 @@ static void hiscoresLoop() {
 //=============================================================================
 
 void MorseMorsel::run() {
-    canvas = MorseGameMode::enterLandscape(MorsePreferences::leftHanded);
+    canvas = MorseGameMode::enterLandscape(MorsePreferences::leftHanded, 8);
     savedKochFilter = MorsePreferences::kochFilter;   // restored on exit
     mslEnc = MSL_ENC_SPEED;
     mslLoadPrefs();                                   // word length + scores

--- a/Software/src/Version 6 and newer/MorseMorsel.h
+++ b/Software/src/Version 6 and newer/MorseMorsel.h
@@ -29,16 +29,20 @@
 #define MSL_SCREEN_W       304
 #define MSL_SCREEN_H       170
 
-// ---- Colour palette (RGB565) ----
-#define MSL_BG             0x0841       // dark near-black
-#define MSL_TEXT           0xFFFF       // white — body text
-#define MSL_DIM            0xBDF7       // light grey — secondary/hints
-#define MSL_ACCENT         0x07FF       // cyan — headings
-#define MSL_HIGHLIGHT      0xFFE0       // yellow — CW playing, warnings
-#define MSL_RED            0xF800       // red — wrong letter
-#define MSL_GREEN          0x07E0       // green — correct letter/position
-#define MSL_GREY           0x528A       // grey — revealed slot keyed wrong
-#define MSL_FRAME          0x528A       // mid-blue — decorative frames
+// ---- Colour palette ----
+// The game sprite is 8-bpp indexed (see GamePalette.h): these names map to
+// shared palette indices, not RGB565 values. The palette entries hold the
+// exact RGB565 colours used before, so the on-screen result is unchanged.
+#include "GamePalette.h"
+#define MSL_BG             PAL_BG          // 0x0841 dark near-black
+#define MSL_TEXT           PAL_WHITE       // 0xFFFF white — body text
+#define MSL_DIM            PAL_LIGHTGREY   // 0xBDF7 light grey — secondary/hints
+#define MSL_ACCENT         PAL_CYAN        // 0x07FF cyan — headings
+#define MSL_HIGHLIGHT      PAL_YELLOW      // 0xFFE0 yellow — CW playing, warnings
+#define MSL_RED            PAL_RED         // 0xF800 red — wrong letter
+#define MSL_GREEN          PAL_GREEN       // 0x07E0 green — correct letter/position
+#define MSL_GREY           PAL_MIDBLUE     // 0x528A grey — revealed slot keyed wrong
+#define MSL_FRAME          PAL_MIDBLUE     // 0x528A mid-blue — decorative frames
 
 // ---- Game states ----
 enum MslState : uint8_t {

--- a/Software/src/Version 6 and newer/MorsePileup.cpp
+++ b/Software/src/Version 6 and newer/MorsePileup.cpp
@@ -66,15 +66,20 @@ static const int  CODE_CHARS_LEN = 36;
 // (see MorseGameMode.cpp) to leave heap headroom for ESP-NOW/BT/WiFi.
 // The bottom 16 px of the panel are not drawn; UI must lay out within FTP_H.
 #define FTP_H  304
-#define FTP_BG     0x0841
-#define FTP_TEXT   0xFFFF
-#define FTP_ACCENT 0x07FF
-#define FTP_OK     0x07E0
-#define FTP_WARN   0xF800
-#define FTP_TITLE  0xFFE0
-#define FTP_DIM    0x7BEF
-#define FTP_INPUT  0x001F      // blue for input text
-#define FTP_ATTACK 0xF81F      // magenta for attack prompt
+// The game sprite is 8-bpp indexed (see GamePalette.h): these names map to
+// shared palette indices, not RGB565 values. The palette entries hold the
+// exact RGB565 colours used before, so the on-screen result is unchanged.
+#include "GamePalette.h"
+#define FTP_BG     PAL_BG        // 0x0841
+#define FTP_TEXT   PAL_WHITE     // 0xFFFF
+#define FTP_ACCENT PAL_CYAN      // 0x07FF
+#define FTP_OK     PAL_GREEN     // 0x07E0
+#define FTP_WARN   PAL_RED       // 0xF800
+#define FTP_TITLE  PAL_YELLOW    // 0xFFE0
+#define FTP_DIM    PAL_GREY      // 0x7BEF
+#define FTP_INPUT  PAL_BLUE      // 0x001F blue for input text
+#define FTP_ATTACK PAL_MAGENTA   // 0xF81F magenta for attack prompt
+#define FTP_BAND   PAL_DARKGREY  // 0x2104 dark grey status/footer band
 
 // Difficulty presets
 //                              label       timeout  spawnMax spawnMin initCal dropsPerLife
@@ -1050,15 +1055,15 @@ static void drawInputArea() {
     }
 
     // Bottom status bar
-    canvas->fillRect(0, 290, FTP_W, 30, 0x2104);
+    canvas->fillRect(0, 290, FTP_W, 30, FTP_BAND);
     canvas->setFont(&fonts::Font0);
     char buf[32];
     snprintf(buf, sizeof(buf), "%d wpm", ftp.wpm);
-    canvas->setTextColor(FTP_TEXT, 0x2104);
+    canvas->setTextColor(FTP_TEXT, FTP_BAND);
     canvas->drawString(buf, 4, 298);
 
     if (ftp.singlePlayer) {
-        canvas->setTextColor(FTP_TITLE, 0x2104);
+        canvas->setTextColor(FTP_TITLE, FTP_BAND);
         canvas->setTextDatum(lgfx::top_right);
         canvas->drawString("SOLO", FTP_W - 4, 298);
         canvas->setTextDatum(lgfx::top_left);
@@ -1459,18 +1464,18 @@ static void statePileup() {
         drawCentredText(218, "Click:submit FN:spd/vol", FTP_DIM);
 
         // Status bar
-        canvas->fillRect(0, 290, FTP_W, 30, 0x2104);
+        canvas->fillRect(0, 290, FTP_W, 30, FTP_BAND);
         canvas->setFont(&fonts::Font0);
         {
             char buf[20];
             snprintf(buf, sizeof(buf), "%d wpm%s", ftp.wpm,
                      encoderIsVolume ? "" : " <");
-            canvas->setTextColor(encoderIsVolume ? FTP_DIM : FTP_TEXT, 0x2104);
+            canvas->setTextColor(encoderIsVolume ? FTP_DIM : FTP_TEXT, FTP_BAND);
             canvas->drawString(buf, 4, 294);
             snprintf(buf, sizeof(buf), "%sVol %d",
                      encoderIsVolume ? "< " : "",
                      MorsePreferences::sidetoneVolume);
-            canvas->setTextColor(encoderIsVolume ? FTP_TEXT : FTP_DIM, 0x2104);
+            canvas->setTextColor(encoderIsVolume ? FTP_TEXT : FTP_DIM, FTP_BAND);
             canvas->drawString(buf, 4, 306);
         }
 
@@ -1580,7 +1585,7 @@ static void stateGameOver() {
 //=== Main entry point ===
 
 void MorsePileup::run() {
-    canvas = MorseGameMode::enterPortrait(MorsePreferences::leftHanded);
+    canvas = MorseGameMode::enterPortrait(MorsePreferences::leftHanded, 8);
     if (!canvas) return;
 
     loadPlayerIdentity();

--- a/Software/src/Version 6 and newer/MorseRadioCave.cpp
+++ b/Software/src/Version 6 and newer/MorseRadioCave.cpp
@@ -2710,7 +2710,7 @@ void MorseRadioCave::run() {
     // MorseGameMode::enterLandscape() doesn't return on allocation failure
     // — it triggers a memory-clearing reboot and resumes directly into
     // this game on the next boot. So canvas is always non-null here.
-    canvas = MorseGameMode::enterLandscape(MorsePreferences::leftHanded);
+    canvas = MorseGameMode::enterLandscape(MorsePreferences::leftHanded, 8);
 
     rcState = RC_LOBBY;
 

--- a/Software/src/Version 6 and newer/MorseRadioCave.h
+++ b/Software/src/Version 6 and newer/MorseRadioCave.h
@@ -35,16 +35,20 @@
 #define RC_MAIN_BOTTOM    (RC_SCREEN_H - RC_BOTBAR_H - 2)
 #define RC_MAIN_H         (RC_MAIN_BOTTOM - RC_MAIN_TOP)
 
-// ---- Colour palette (RGB565) ----
+// ---- Colour palette ----
+// The game sprite is 8-bpp indexed (see GamePalette.h): these names map to
+// shared palette indices, not RGB565 values. The palette entries hold the
+// exact RGB565 colours used before, so the on-screen result is unchanged.
 // All foreground colors tested for readability on near-black background.
-#define RC_BG             0x0841       // dark near-black
-#define RC_TEXT           0xFFFF       // white — body text
-#define RC_DIM            0xBDF7       // light grey — secondary/hints
-#define RC_ACCENT         0x07FF       // cyan — headings, room names
-#define RC_HIGHLIGHT      0xFFE0       // yellow — CW playing, warnings
-#define RC_DANGER         0xF800       // red — death, errors
-#define RC_OK             0x07E0       // green — success feedback
-#define RC_FRAME          0x528A       // mid-blue — decorative frames (visible on black)
+#include "GamePalette.h"
+#define RC_BG             PAL_BG          // 0x0841 dark near-black
+#define RC_TEXT           PAL_WHITE       // 0xFFFF white — body text
+#define RC_DIM            PAL_LIGHTGREY   // 0xBDF7 light grey — secondary/hints
+#define RC_ACCENT         PAL_CYAN        // 0x07FF cyan — headings, room names
+#define RC_HIGHLIGHT      PAL_YELLOW      // 0xFFE0 yellow — CW playing, warnings
+#define RC_DANGER         PAL_RED         // 0xF800 red — death, errors
+#define RC_OK             PAL_GREEN       // 0x07E0 green — success feedback
+#define RC_FRAME          PAL_MIDBLUE     // 0x528A mid-blue — decorative frames
 
 // ---- Save format ----
 #define RC_SAVE_VERSION   1            // bump if save-blob layout changes


### PR DESCRIPTION
## Summary

First of two stages converting the game sprite from 16-bpp (RGB565) to 8-bpp indexed (palette) colour, halving its heap footprint (~99 KB → ~50 KB at the current trim). This removes the heap pressure that made the sprite and WiFi/ESP-NOW compete for the same large contiguous block.

**Why indexed colour, and why it's safe:** LovyanGFX's 8-bpp mode is *pure* indexed colour — the colour argument to a draw call is masked to its low byte and used directly as a palette index (no nearest-colour matching). The games already route every colour through named macros (`FTP_*`, `MSL_*`, `RC_*`), so the conversion is concentrated in the macro definitions and a shared palette; **call sites are untouched**. The palette holds the exact RGB565 values used before, so output is pixel-identical.

### Changes
- **New `GamePalette.h`** — shared 13-entry palette (`PAL_*` indices) covering every colour the three games use.
- **`MorseGameMode`** — `enterPortrait`/`enterLandscape` gain a `colorDepth` parameter (default `16`, preserving current behaviour). At `8` bpp it loads the shared palette into the sprite after `createSprite`.
- **Morsel, Fight the Pileup, Radio Cave** — colour macros redefined to `PAL_*` indices; each requests an 8-bpp sprite. Pileup's one raw `0x2104` band literal becomes `FTP_BAND → PAL_DARKGREY`.

**Morse Invaders is intentionally left at 16 bpp** — it does runtime RGB arithmetic on invader colours (brightened borders) and needs a separate conversion (Stage 2, follow-up PR).

### Known follow-ups (not in this PR)
- Right-edge letter cutoff in landscape games — pre-existing consequence of the trim=28 bump in #162 (sprite 292 px wide vs 304 px layout), unrelated to colour depth.
- Heap-probe confirmation of the ~50 KB sprite size.

## Test plan

- [x] `pocketwroom` (TFT) builds clean
- [x] `heltec_wifi_lora_32_V2` (OLED) builds clean
- [x] On M32 Pocket: Morsel, Fight the Pileup, Radio Cave all render with correct, unchanged colours
- [ ] Heap-size confirmation (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)