### PR TITLE
Restore full sprite width (trim 28 → 16) after 8-bpp conversion

### DIFF
--- a/Software/src/Version 6 and newer/MorseGameMode.cpp
+++ b/Software/src/Version 6 and newer/MorseGameMode.cpp
@@ -48,18 +48,19 @@ extern uint32_t rebootMagic;
 extern uint8_t  rebootMenuPtr;
 
 // Pixels removed from the long side of the panel when sizing the sprite.
-// At 170×320, trimming 28 from the long side gives a 170×292 / 292×170
-// sprite (= 99,280 bytes), ~4 KB smaller than the 16-px-trim version.
-// Bumped from 16 to 28 to leave a comfortable margin between the sprite
-// and the largest free contiguous heap block after a setupESPNow /
-// setupWifi cycle. Heap probes measured (free / largest contiguous):
-//   clean boot     163 KB / 106 KB    sprite + 7 KB margin
-//   after WiFi     120 KB / 106 KB    sprite + 7 KB margin
-//   after ESP-NOW  113 KB / 102 KB    sprite + 3 KB margin
-// Decrease only after re-running the heap diagnostics and confirming
-// there's still headroom.
+// At 170×320 and 8-bpp (1 byte/pixel, see GamePalette.h), trimming 16
+// gives a 304×170 sprite (= 51,680 bytes + palette). 304 matches the
+// games' layout width exactly, so nothing is clipped on the long edge.
+//
+// This was 28 while the sprite was 16-bpp (~99 KB), needed to keep a
+// thin ~3 KB margin against the largest free block after ESP-NOW. The
+// 8-bpp conversion halved the sprite, so we restored the full layout
+// width. Heap probes after the conversion (free / largest contiguous):
+//   clean boot          163 KB / 106 KB
+//   after sprite alloc  110 KB /  55 KB   (sprite ~52 KB)
+//   after setupESPNow   110 KB /  98 KB   → sprite + ESP-NOW: ~46 KB margin
 #ifndef MORSE_GAMEMODE_SPRITE_TRIM
-#define MORSE_GAMEMODE_SPRITE_TRIM 28
+#define MORSE_GAMEMODE_SPRITE_TRIM 16
 #endif
 
 namespace {


### PR DESCRIPTION
## Summary

Now that all four games run on the 8-bpp palette sprite (#165, #166), the sprite is ~52 KB instead of ~99 KB. The heap pressure that forced `MORSE_GAMEMODE_SPRITE_TRIM` up to 28 (in #162) is gone, so this drops it back to **16** — a 304×170 sprite whose width matches the games' layout exactly, **removing the right-edge letter clipping** the 28-px trim introduced in the landscape games (Morsel, Radio Cave).

**Stacked on #166.** Merge order: #165 → #166 → this.

### Measured heap (M32 Pocket, 8-bpp, trim=16)

| State | Free | Largest contiguous |
|---|---:|---:|
| Boot | 163 KB | 106 KB |
| After sprite alloc | 110 KB | 55 KB (sprite ~52 KB) |
| After setupESPNow | 110 KB | 98 KB |

Sprite + ESP-NOW margin: **~46 KB** (was ~3 KB at 16-bpp / trim 28). The heap-budget problem that motivated this whole line of work is resolved with comfortable headroom.

## Test plan

- [x] `pocketwroom` builds clean
- [x] On M32 Pocket: right-edge letter cutoff gone in Morsel and Radio Cave
- [x] Heap margin confirmed via probes (stripped before commit)
- [x] All four games render correctly at the restored width

🤖 Generated with [Claude Code](https://claude.com/claude-code)