### PR TITLE
Land Invaders 8-bpp + trim=16 on master (recovery for stranded #166/#167)

### DIFF
--- a/Software/src/Version 6 and newer/GamePalette.h
+++ b/Software/src/Version 6 and newer/GamePalette.h
@@ -40,6 +40,21 @@ enum GamePaletteIndex : uint8_t {
   PAL_BLUE,         // 0x001F  blue — input text
   PAL_MAGENTA,      // 0xF81F  magenta — attack prompt
   PAL_DARKGREY,     // 0x2104  dark grey — status/footer band
+
+  // Morse Invaders character-category colours: each invader is filled in a
+  // category colour and outlined in a dimmed version of it. The border
+  // values are the exact result of the old runtime brightening
+  // (color565(R5*4, G6*2, B5*4)) precomputed, since palette indices can't
+  // be brightened arithmetically.
+  PAL_INV_LETTERS,    // 0x0400  dark green   (fill)
+  PAL_INV_NUMBERS,    // 0x8400  dark yellow  (fill)
+  PAL_INV_PUNCT,      // 0x8200  dark orange  (fill)
+  PAL_INV_PROSIGN,    // 0x8010  dark magenta (fill)
+  PAL_INV_LETTERS_B,  // 0x0200  letters border
+  PAL_INV_NUMBERS_B,  // 0x4200  numbers border
+  PAL_INV_PUNCT_B,    // 0x4100  punct border
+  PAL_INV_PROSIGN_B,  // 0x4008  prosign border
+
   PAL_COUNT         // number of palette entries in use
 };
 

--- a/Software/src/Version 6 and newer/MorseGame.cpp
+++ b/Software/src/Version 6 and newer/MorseGame.cpp
@@ -250,6 +250,7 @@ static char   pollKeyedChar();
 static int    findMatchingInvader(char c);
 static void   destroyInvader(int idx);
 static uint16_t getCharColor(char c);
+static uint16_t getCharBorderColor(char c);
 static void   getDisplayStr(char c, char* buf);
 
 static void   drawGameField();
@@ -314,6 +315,19 @@ static uint16_t getCharColor(char c) {
     return GC_LETTERS;
 }
 
+// Dimmed outline colour for an invader, matching its fill category. Under
+// the 8-bpp palette the old runtime brightening (color565 on the fill's
+// RGB components) can't be done on an index, so the four results are
+// precomputed as their own palette entries (PAL_INV_*_B).
+static uint16_t getCharBorderColor(char c) {
+    if (c >= '0' && c <= '9') return PAL_INV_NUMBERS_B;
+    if (c == '.' || c == ',' || c == '?' || c == '/' || c == '-' || c == '=' || c == ':')
+        return PAL_INV_PUNCT_B;
+    if (c == 'S' || c == 'A' || c == 'N' || c == 'K' || c == 'E' || c == 'B' || c == '+')
+        return PAL_INV_PROSIGN_B;
+    return PAL_INV_LETTERS_B;
+}
+
 static void getDisplayStr(char c, char* buf) {
     bool upper = (MorsePreferences::pliste[posOutputCase].value != 0);
     switch (c) {
@@ -374,6 +388,7 @@ static void spawnInvader() {
     inv.y = GAME_FIELD_TOP;
     inv.speed = game.baseSpeed + random(0, 30) / 100.0f;
     inv.color = getCharColor(inv.character);
+    inv.borderColor = getCharBorderColor(inv.character);
     inv.active = true;
     inv.explodeFrame = 0;
 }
@@ -483,11 +498,7 @@ static void drawInvader(GameInvader& inv) {
     if (!inv.active) return;
 
     canvas->fillRoundRect(x, y, GAME_INVADER_W, GAME_INVADER_H, 4, inv.color);
-    canvas->drawRoundRect(x, y, GAME_INVADER_W, GAME_INVADER_H, 4,
-        canvas->color565(
-            ((inv.color >> 11) & 0x1F) * 4,
-            ((inv.color >> 5) & 0x3F) * 2,
-            (inv.color & 0x1F) * 4));
+    canvas->drawRoundRect(x, y, GAME_INVADER_W, GAME_INVADER_H, 4, inv.borderColor);
 
     char dispBuf[4];
     getDisplayStr(inv.character, dispBuf);
@@ -533,7 +544,7 @@ static void drawInvader(GameInvader& inv) {
 static void drawGameField() {
     for (int i = 0; i <= GAME_NUM_LANES; i++) {
         int x = GAME_LANE_MARGIN + i * GAME_LANE_W;
-        canvas->drawFastVLine(x, GAME_FIELD_TOP, GAME_FIELD_BOTTOM - GAME_FIELD_TOP, 0x2104);
+        canvas->drawFastVLine(x, GAME_FIELD_TOP, GAME_FIELD_BOTTOM - GAME_FIELD_TOP, GC_BAND);
     }
     for (int i = 0; i < GAME_MAX_INVADERS; i++)
         if (game.invaders[i].active || game.invaders[i].explodeFrame > 0)
@@ -561,33 +572,33 @@ static void drawHUD() {
 }
 
 static void drawKeyingZone() {
-    canvas->fillRect(0, GAME_KEYING_Y, GAME_SCREEN_W, GAME_SCREEN_H - GAME_KEYING_Y, 0x2104);
+    canvas->fillRect(0, GAME_KEYING_Y, GAME_SCREEN_W, GAME_SCREEN_H - GAME_KEYING_Y, GC_BAND);
 
     canvas->setFont(&fonts::Font0);
     char infoBuf[16];
     if (encoderIsVolume) {
         snprintf(infoBuf, sizeof(infoBuf), "Vol:%d <", MorsePreferences::sidetoneVolume);
-        canvas->setTextColor(GC_LEVELUP, 0x2104);
+        canvas->setTextColor(GC_LEVELUP, GC_BAND);
     } else {
         snprintf(infoBuf, sizeof(infoBuf), "%d wpm <", game.wpm);
-        canvas->setTextColor(GC_HUD_TEXT, 0x2104);
+        canvas->setTextColor(GC_HUD_TEXT, GC_BAND);
     }
     canvas->drawString(infoBuf, 4, GAME_KEYING_Y + 4);
 
     // Show the other value (without <) on the second line
     if (encoderIsVolume) {
         snprintf(infoBuf, sizeof(infoBuf), "%d wpm", game.wpm);
-        canvas->setTextColor(GC_HUD_TEXT, 0x2104);
+        canvas->setTextColor(GC_HUD_TEXT, GC_BAND);
     } else {
         snprintf(infoBuf, sizeof(infoBuf), "Vol:%d", MorsePreferences::sidetoneVolume);
-        canvas->setTextColor(GC_HUD_TEXT, 0x2104);
+        canvas->setTextColor(GC_HUD_TEXT, GC_BAND);
     }
     canvas->drawString(infoBuf, 4, GAME_KEYING_Y + 18);
 
     if (game.streak >= 5) {
         char streakBuf[12];
         snprintf(streakBuf, sizeof(streakBuf), "x%d", game.streak);
-        canvas->setTextColor(GC_LEVELUP, 0x2104);
+        canvas->setTextColor(GC_LEVELUP, GC_BAND);
         canvas->setTextDatum(lgfx::top_right);
         canvas->drawString(streakBuf, GAME_SCREEN_W - 4, GAME_KEYING_Y + 4);
         canvas->setTextDatum(lgfx::top_left);
@@ -597,7 +608,7 @@ static void drawKeyingZone() {
         char dispBuf[4];
         getDisplayStr(lastDecodedChar, dispBuf);
         canvas->setFont(&fonts::FreeSansBold12pt7b);
-        canvas->setTextColor(GC_HUD_TEXT, 0x2104);
+        canvas->setTextColor(GC_HUD_TEXT, GC_BAND);
         canvas->setTextDatum(lgfx::middle_center);
         canvas->drawString(dispBuf, GAME_SCREEN_W / 2, GAME_KEYING_Y + 21);
         canvas->setTextDatum(lgfx::top_left);
@@ -1020,7 +1031,7 @@ static void stateGameOver() {
 //=============================================================================
 
 void MorseGame::run() {
-    canvas = MorseGameMode::enterPortrait(false);
+    canvas = MorseGameMode::enterPortrait(false, 8);
     if (!canvas) return;
     // Determine character rotation from preference
     // posInvaderOrient: 0 = game native (no rotation), 1 = reading orientation
@@ -1039,11 +1050,15 @@ void MorseGame::run() {
         tileSprite = new LGFX_Sprite(canvas);
         if (tileSprite) {
             tileSprite->setPsram(false);
-            tileSprite->setColorDepth(16);
+            tileSprite->setColorDepth(8);
             if (!tileSprite->createSprite(GAME_INVADER_H, GAME_INVADER_W)) {
                 delete tileSprite;
                 tileSprite = nullptr;
                 charRotation = 0;  // fall back to no rotation
+            } else {
+                // Share the main sprite's palette so index values blit
+                // unchanged between tileSprite and canvas (pushRotateZoom).
+                MorseGameMode::applyGamePalette(tileSprite);
             }
         }
     }

--- a/Software/src/Version 6 and newer/MorseGame.h
+++ b/Software/src/Version 6 and newer/MorseGame.h
@@ -42,18 +42,23 @@ extern char gameCharBuffer;
 // game-mode entry); UI must lay out within GAME_SCREEN_H.
 #define GAME_SCREEN_H       304
 
-// ---- Colour palette (RGB565) ----
-#define GC_BG           0x0841
-#define GC_LETTERS      0x0400    // dark green
-#define GC_NUMBERS      0x8400    // dark yellow
-#define GC_PUNCT        0x8200    // dark orange
-#define GC_PROSIGN      0x8010    // dark magenta
-#define GC_HUD_TEXT     0xFFFF
-#define GC_LIVES        0xF800
-#define GC_SCORE        0x07FF
-#define GC_LEVELUP      0xFFE0
-#define GC_GAMEOVER     0xF800
-#define GC_MISS         0x7BEF
+// ---- Colour palette ----
+// The game sprite is 8-bpp indexed (see GamePalette.h): these names map to
+// shared palette indices, not RGB565 values. The palette entries hold the
+// exact RGB565 colours used before, so the on-screen result is unchanged.
+#include "GamePalette.h"
+#define GC_BG           PAL_BG            // 0x0841
+#define GC_LETTERS      PAL_INV_LETTERS   // 0x0400 dark green
+#define GC_NUMBERS      PAL_INV_NUMBERS   // 0x8400 dark yellow
+#define GC_PUNCT        PAL_INV_PUNCT     // 0x8200 dark orange
+#define GC_PROSIGN      PAL_INV_PROSIGN   // 0x8010 dark magenta
+#define GC_HUD_TEXT     PAL_WHITE         // 0xFFFF
+#define GC_LIVES        PAL_RED           // 0xF800
+#define GC_SCORE        PAL_CYAN          // 0x07FF
+#define GC_LEVELUP      PAL_YELLOW        // 0xFFE0
+#define GC_GAMEOVER     PAL_RED           // 0xF800
+#define GC_MISS         PAL_GREY          // 0x7BEF
+#define GC_BAND         PAL_DARKGREY      // 0x2104 HUD / keying-zone band
 
 // ---- Game states ----
 enum GameStateEnum : uint8_t {
@@ -67,7 +72,8 @@ struct GameInvader {
     uint8_t  lane;
     float    y;
     float    speed;
-    uint16_t color;
+    uint16_t color;        // fill palette index (PAL_INV_*)
+    uint16_t borderColor;  // dimmed outline palette index (PAL_INV_*_B)
     bool     active;
     uint8_t  explodeFrame;
 };

--- a/Software/src/Version 6 and newer/MorseGameMode.cpp
+++ b/Software/src/Version 6 and newer/MorseGameMode.cpp
@@ -48,18 +48,19 @@ extern uint32_t rebootMagic;
 extern uint8_t  rebootMenuPtr;
 
 // Pixels removed from the long side of the panel when sizing the sprite.
-// At 170×320, trimming 28 from the long side gives a 170×292 / 292×170
-// sprite (= 99,280 bytes), ~4 KB smaller than the 16-px-trim version.
-// Bumped from 16 to 28 to leave a comfortable margin between the sprite
-// and the largest free contiguous heap block after a setupESPNow /
-// setupWifi cycle. Heap probes measured (free / largest contiguous):
-//   clean boot     163 KB / 106 KB    sprite + 7 KB margin
-//   after WiFi     120 KB / 106 KB    sprite + 7 KB margin
-//   after ESP-NOW  113 KB / 102 KB    sprite + 3 KB margin
-// Decrease only after re-running the heap diagnostics and confirming
-// there's still headroom.
+// At 170×320 and 8-bpp (1 byte/pixel, see GamePalette.h), trimming 16
+// gives a 304×170 sprite (= 51,680 bytes + palette). 304 matches the
+// games' layout width exactly, so nothing is clipped on the long edge.
+//
+// This was 28 while the sprite was 16-bpp (~99 KB), needed to keep a
+// thin ~3 KB margin against the largest free block after ESP-NOW. The
+// 8-bpp conversion halved the sprite, so we restored the full layout
+// width. Heap probes after the conversion (free / largest contiguous):
+//   clean boot          163 KB / 106 KB
+//   after sprite alloc  110 KB /  55 KB   (sprite ~52 KB)
+//   after setupESPNow   110 KB /  98 KB   → sprite + ESP-NOW: ~46 KB margin
 #ifndef MORSE_GAMEMODE_SPRITE_TRIM
-#define MORSE_GAMEMODE_SPRITE_TRIM 28
+#define MORSE_GAMEMODE_SPRITE_TRIM 16
 #endif
 
 namespace {
@@ -83,6 +84,14 @@ namespace {
     0x001F,  // PAL_BLUE
     0xF81F,  // PAL_MAGENTA
     0x2104,  // PAL_DARKGREY
+    0x0400,  // PAL_INV_LETTERS
+    0x8400,  // PAL_INV_NUMBERS
+    0x8200,  // PAL_INV_PUNCT
+    0x8010,  // PAL_INV_PROSIGN
+    0x0200,  // PAL_INV_LETTERS_B
+    0x4200,  // PAL_INV_NUMBERS_B
+    0x4100,  // PAL_INV_PUNCT_B
+    0x4008,  // PAL_INV_PROSIGN_B
   };
 
   // Restore the Morserino menu's display state. Used both by exit() and by
@@ -175,6 +184,14 @@ void MorseGameMode::warmup() {
   tmp.pushSprite(lcd, 0, 0);
   lcd->endWrite();
   tmp.deleteSprite();
+}
+
+void MorseGameMode::applyGamePalette(LGFX_Sprite *s) {
+  // Load the shared 8-bpp game palette into a caller-owned sprite (e.g.
+  // Invaders' rotated-text tile sprite) so it matches the main game
+  // sprite's palette — index-for-index — and blits between them stay
+  // colour-correct. Single source of truth for the palette table.
+  if (s) s->createPalette(kGamePalette, PAL_COUNT);
 }
 
 LGFX_Sprite *MorseGameMode::enterPortrait(bool leftHanded, uint8_t colorDepth) {

--- a/Software/src/Version 6 and newer/MorseGameMode.h
+++ b/Software/src/Version 6 and newer/MorseGameMode.h
@@ -47,6 +47,12 @@ namespace MorseGameMode {
   // enterPortrait — reboots on allocation failure.
   LGFX_Sprite *enterLandscape(bool leftHanded, uint8_t colorDepth = 16);
 
+  // Load the shared 8-bpp game palette (GamePalette.h) into a
+  // caller-owned sprite. Used by games that allocate their own secondary
+  // 8-bpp sprite (e.g. Invaders' rotated-text tile) and need it to share
+  // the main sprite's palette so blits between the two stay colour-correct.
+  void applyGamePalette(LGFX_Sprite *s);
+
   // Push the sprite to the panel.
   void pushFrame();
 


### PR DESCRIPTION
## Why this PR exists

PRs #166 (Invaders 8-bpp) and #167 (trim 28→16) show as **merged** on GitHub, but their content never reached `master`. They were stacked PRs (#166 based on #165's branch, #167 on #166's branch). All three were merged within ~30 seconds, before GitHub retargeted the stacked bases onto master after #165 landed — so #166 merged into `claude/sprite-8bpp` and #167 into `claude/sprite-8bpp-invaders`, not master.

Net effect on master: only Stage 1 landed. **Invaders is still 16-bpp and the sprite trim is still 28.**

## What this does

Re-applies the already-reviewed delta so master gets the complete 8-bpp work. The resulting tree is **identical** to the tip of `claude/sprite-8bpp-invaders` (the fully-merged stack):

- **Morse Invaders → 8-bpp palette**: `GC_*` macros → `PAL_*` indices; the four dimmed invader-border colours precomputed as palette entries with a `getCharBorderColor()` lookup; rotated-text `tileSprite` is 8-bpp and shares the palette via `MorseGameMode::applyGamePalette()`.
- **`MORSE_GAMEMODE_SPRITE_TRIM` 28 → 16** — 304-wide sprite, exact layout fit, no right-edge clipping, now affordable because 8-bpp halved the sprite (~52 KB).

No new code vs. what was reviewed in #166/#167.

## Test plan

- [x] `pocketwroom` builds clean
- [x] Tree matches `claude/sprite-8bpp-invaders` exactly (`git diff` empty)
- [x] All four games already hardware-validated during #165–#167

🤖 Generated with [Claude Code](https://claude.com/claude-code)