### PR TITLE
Pin QuickEspNow to fixed fork (crash + leak across WiFi cycles)

### DIFF
--- a/Software/src/platformio.ini
+++ b/Software/src/platformio.ini
@@ -24,7 +24,15 @@ extra_scripts = pre:scripts/clean_ino_dupes.py
 lib_deps_external =
 	bblanchon/ArduinoJson@6.20.1
 	madhephaestus/ESP32Encoder @ ^0.11.7
-	gmag11/QuickEspNow@^0.8.1
+	; QuickEspNow: pinned to our fork until upstream cuts a release past 0.8.1.
+	; Brings two fixes the released 0.8.1 lacks:
+	;  - addPeer() self-heals a stale peer instead of abort()ing (upstream
+	;    main, PR gmag11/QuickEspNow#20) — fixes the crash on the 2nd ESP-NOW
+	;    session after a WiFi mode cycle;
+	;  - stop() now frees its tx/rx queues (our PR gmag11/QuickEspNow#25) —
+	;    fixes a per-cycle RAM leak.
+	; Revert to the registry version once a release contains both.
+	https://github.com/oe1wkl/QuickEspNow.git#2b26917baa2a4a6855002864e62805f647f0499c
 LoRa_lib_deps =
 	jgromes/RadioLib@^7.1.0
 M32_Pocket_board_lib_deps =


### PR DESCRIPTION
## Summary

Switches the `QuickEspNow` dependency from the released `0.8.1` to our fork pinned at a specific commit, picking up two fixes that `0.8.1` lacks:

1. **Crash fix** (from upstream `main`, PR [gmag11/QuickEspNow#20](https://github.com/gmag11/QuickESPNow/pull/20), merged but unreleased): `addPeer()` self-heals a stale peer instead of `abort()`ing. In `0.8.1`, the second ESP-NOW session after a WiFi mode cycle hits `ESP_ERROR_CHECK(esp_now_get_peer(...))` on a peer that `esp_now_deinit()` already removed but `peer_list` still tracks → panic. This is the root cause of the memory-clearing reboot the firmware currently forces before games when WiFi was used.
2. **Leak fix** (our PR [gmag11/QuickESPNow#25](https://github.com/gmag11/QuickESPNow/pull/25)): `stop()` now frees the tx/rx FreeRTOS queues it created, instead of orphaning a pair (~few KB) every `stop()`/`begin()` cycle.

Pinned to `oe1wkl/QuickEspNow@2b26917` (commit carrying both). The `platformio.ini` comment documents why and says to revert to the registry version once upstream cuts a release containing both.

## Scope

Dependency pin only — **no source or behaviour change**. The `rebootIfWifiAlreadyUsed()` guards stay in place for now; removing them (the actual payoff) is a separate, hardware-validated follow-up so we can stress-test repeated WiFi ↔ ESP-NOW ↔ game cycles before dropping the reboot safety net.

## Test plan

- [x] `pocketwroom` builds clean against the fork
- [x] `heltec_wifi_lora_32_V2` builds clean against the fork
- [x] Library Manager resolves the pinned commit (`QuickEspNow@0.8.1+sha.2b26917`)
- [ ] Follow-up: remove reboot guards, validate repeated cycles on hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)