### PR TITLE
Morsel MP: tear down ESP-NOW on exit to avoid a re-entry reboot

### DIFF
--- a/Software/src/Version 6 and newer/MorseMorsel.cpp
+++ b/Software/src/Version 6 and newer/MorseMorsel.cpp
@@ -1461,10 +1461,21 @@ void MorseMorsel::run() {
         }
     }
 
-    // Stop routing ESP-NOW packets to Morsel. The WiFi/ESP-NOW stack itself
-    // is torn down by MorseMenu::menu_() on return (it owns EspNowIsActive).
+    // Stop routing ESP-NOW packets to Morsel, and tear down the radio we
+    // brought up for multiplayer. This must happen here, not lean on
+    // menu_()'s teardown: returning from a game keeps us inside the still-
+    // running menu_() loop, so its entry-time WiFi/ESP-NOW teardown does NOT
+    // re-run between two game launches. If ESP-NOW were left up, re-entering
+    // Morsel would allocate the 52 KB sprite against a heap still fragmented
+    // by ESP-NOW (free is ample, but the largest contiguous block drops just
+    // below the sprite size) and the allocation would fail into a reboot.
     MorseMorsel::morselNetMode = false;
     mpRole = MP_NONE;
+    if (EspNowIsActive) {
+        quickEspNow.stop();
+        EspNowIsActive = false;
+        WiFi.mode(WIFI_OFF);
+    }
 
     cwStop();
     keyOut(false, true, 0, 0);


### PR DESCRIPTION
## Summary

Exiting a Morsel multiplayer session and re-entering Morsel could trip the sprite-allocation OOM reboot. Heap probes pinned it down — it's **not** memory exhaustion:

```
gm-exit-after   free=110196  maxblk=51188   ← ESP-NOW still up
allocate need=51680  maxblk=51188  → createSprite FAILED → reboot   (short by 492 bytes)
```

~110 KB free, but the largest *contiguous* block was 51 188 — just under the 51 680-byte sprite.

**Cause:** `menu_()` tears WiFi/ESP-NOW down only when it is *entered*. A game returns via `menuExec()` returning `false`, which stays inside the already-running `menu_()` loop, so that teardown never re-runs between two game launches. ESP-NOW stayed up after the MP session and kept the heap fragmented; the next Morsel entry allocated its sprite against that fragmented heap and failed.

**Fix:** `MorseMorsel::run()` now tears down the ESP-NOW radio it brought up (`quickEspNow.stop()` + `WiFi.mode(WIFI_OFF)`) as part of its exit, alongside clearing `morselNetMode`. The game cleans up what it started rather than leaning on `menu_()`'s entry-time teardown.

Post-fix probes: largest contiguous block recovers from 51 KB to **59 KB** on MP exit, so the sprite re-allocates with ~7.7 KB margin.

## Test plan
- [x] Enter Morsel → Multiplayer → exit → re-enter Morsel, repeatedly — no reboot, no crash (was a reliable reboot before)
- [x] Repeated MP up/down cycles work (ESP-NOW re-`begin` after `stop` is fine — QuickEspNow fork)
- [x] Single-player path unaffected (ESP-NOW never brought up there)
- [x] Both `pocketwroom` and `heltec_wifi_lora_32_V2` build clean

## Note
Fight the Pileup has the same latent pattern (also relies on `menu_()`'s teardown, never stops ESP-NOW itself) — masked by the reboot guard removed in #170. Worth the same one-line treatment in a follow-up if reproducible there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)