### PR TITLE
Fix: TFT-Pocket dark on USB-only power (revert PR #157 source path)

### DIFF
--- a/Software/src/Version 6 and newer/MorseGame.cpp
+++ b/Software/src/Version 6 and newer/MorseGame.cpp
@@ -21,7 +21,7 @@ char gameCharBuffer = 0;
 #include "MorseMenu.h"
 #include "morsedefs.h"
 #include "ClickButton.h"
-#include "M32PocketLGFX.h"
+#include "DisplayWrapper.h"
 
 #include <LovyanGFX.hpp>
 #include <ESP32Encoder.h>
@@ -37,7 +37,7 @@ extern void serialEvent();
 extern boolean checkPaddles();
 extern boolean doPaddleIambic(boolean, boolean);
 extern boolean leftKey, rightKey;
-extern LGFX display;
+extern DisplayWrapper display;
 extern ESP32Encoder rotaryEncoder;
 extern const int PinCLK;
 extern const int PinDT;

--- a/Software/src/Version 6 and newer/MorseGameMode.cpp
+++ b/Software/src/Version 6 and newer/MorseGameMode.cpp
@@ -29,7 +29,7 @@
 #include <Arduino.h>
 #include <ESP32Encoder.h>
 
-#include "M32PocketLGFX.h"
+#include "DisplayWrapper.h"
 #include "MorseOutput.h"
 #include "MorsePreferences.h"
 #include "morsedefs.h"
@@ -98,7 +98,7 @@ namespace {
   // the failure path of allocate() so that callers see a coherent menu
   // regardless of whether enter*() succeeded.
   void restoreMenuDisplay(bool leftHanded) {
-    (&display)->setRotation(leftHanded ? 0 : 2);
+    DisplayWrapper::getLGFX()->setRotation(leftHanded ? 0 : 2);
     MorseOutput::initDisplay();
     MorseOutput::setTheme(MorsePreferences::pliste[posTheme].value);
     pinMode(PinCLK, INPUT_PULLUP);
@@ -115,7 +115,7 @@ namespace {
   LGFX_Sprite *allocate(int rotation, bool leftHanded, uint8_t colorDepth) {
     lastLeftHanded = leftHanded;
 
-    auto *lcd = (&display);
+    auto *lcd = DisplayWrapper::getLGFX();
     lcd->setRotation(rotation);
     lcd->fillScreen(TFT_BLACK);
 
@@ -175,7 +175,7 @@ void MorseGameMode::warmup() {
   // inside a game session. (See module header comment for why timing
   // matters: the lazy alloc otherwise lands inside what would become the
   // game sprite's tail region.)
-  auto *lcd = (&display);
+  auto *lcd = DisplayWrapper::getLGFX();
   LGFX_Sprite tmp(lcd);
   tmp.setColorDepth(16);
   if (!tmp.createSprite(lcd->width(), lcd->height())) return;
@@ -204,7 +204,7 @@ LGFX_Sprite *MorseGameMode::enterLandscape(bool leftHanded, uint8_t colorDepth) 
 
 void MorseGameMode::pushFrame() {
   if (!sprite) return;
-  auto *lcd = (&display);
+  auto *lcd = DisplayWrapper::getLGFX();
   lcd->startWrite();
   sprite->pushSprite(lcd, 0, 0);
   lcd->endWrite();
@@ -231,7 +231,7 @@ LGFX_Sprite *MorseGameMode::getSprite() {
   rebootMagic   = 0xC0FFEE42u;
 
   // Restore portrait rotation so the overlay is readable.
-  (&display)->setRotation(MorsePreferences::leftHanded ? 0 : 2);
+  DisplayWrapper::getLGFX()->setRotation(MorsePreferences::leftHanded ? 0 : 2);
   MorseOutput::initDisplay();
   MorseOutput::clearDisplay();
   MorseOutput::printOnScroll(0, BOLD,    0, "Clearing");

--- a/Software/src/Version 6 and newer/MorseMorsel.cpp
+++ b/Software/src/Version 6 and newer/MorseMorsel.cpp
@@ -31,7 +31,7 @@
 #include "MorseGame.h"           // gameMode, gameCharBuffer
 #include "morsedefs.h"
 #include "ClickButton.h"
-#include "M32PocketLGFX.h"
+#include "DisplayWrapper.h"
 #include "english_words.h"
 #include "abbrev.h"
 #include "DejaVuSansMono_Bold15pt7b.h"

--- a/Software/src/Version 6 and newer/MorseOutput.cpp
+++ b/Software/src/Version 6 and newer/MorseOutput.cpp
@@ -47,8 +47,12 @@
 #include "M32OledLGFX.h"
 LGFX display;
 #else
-#include "M32PocketLGFX.h"
-LGFX display;
+// TFT path — using DisplayWrapper (the V8.0 path). The in-tree LGFX
+// wrapper introduced in #157 left the TFT dark on USB-only-powered
+// Pockets (root cause not yet pinned down); the DisplayWrapper library
+// path is the only one that keeps the panel alive.
+#include "DisplayWrapper.h"
+DisplayWrapper display;
 #endif
 
 #ifdef CONFIG_SOUND_I2S
@@ -1284,7 +1288,7 @@ void MorseOutput::updateBatteryDisplay() {
 void MorseOutput::clearBatteryIcon() {
     if (!batteryIconVisible) return;
 
-    lgfx::LGFX_Device* lcd = &display;
+    lgfx::LGFX_Device* lcd = DisplayWrapper::getLGFX();
 
     const int bodyW = 26, iconH = 16, nubW = 4, margin = 2;
     int ix = lcd->width() - bodyW - nubW - margin;

--- a/Software/src/Version 6 and newer/MorsePileup.cpp
+++ b/Software/src/Version 6 and newer/MorsePileup.cpp
@@ -20,7 +20,7 @@ volatile bool pileupRxReady = false;
 #include "MorseMenu.h"
 #include "morsedefs.h"
 #include "ClickButton.h"
-#include "M32PocketLGFX.h"
+#include "DisplayWrapper.h"
 #include <LovyanGFX.hpp>
 #include <ESP32Encoder.h>
 #include <Preferences.h>
@@ -30,7 +30,7 @@ extern void serialEvent();
 extern boolean checkPaddles();
 extern boolean doPaddleIambic(boolean, boolean);
 extern boolean leftKey, rightKey;
-extern LGFX display;
+extern DisplayWrapper display;
 extern ESP32Encoder rotaryEncoder;
 extern const int PinCLK;
 extern const int PinDT;

--- a/Software/src/Version 6 and newer/MorseRadioCave.cpp
+++ b/Software/src/Version 6 and newer/MorseRadioCave.cpp
@@ -58,7 +58,7 @@
 #include "MorseGame.h"           // gameMode, gameCharBuffer
 #include "morsedefs.h"
 #include "ClickButton.h"
-#include "M32PocketLGFX.h"
+#include "DisplayWrapper.h"
 
 #include <LovyanGFX.hpp>
 #include <ESP32Encoder.h>
@@ -79,7 +79,7 @@ extern unsigned int interWordSpace;
 extern void     updateTimings();
 extern void     keyOut(boolean, boolean, int, int);
 extern String   generateCWword(const String& symbols);   // m32_v6.ino — pure function
-extern LGFX display;
+extern DisplayWrapper display;
 extern ESP32Encoder   rotaryEncoder;
 extern const int      PinCLK;
 extern const int      PinDT;

--- a/Software/src/platformio.ini
+++ b/Software/src/platformio.ini
@@ -46,6 +46,10 @@ M32_Pocket_Heltec_board_lib_deps =
 M32_Pocket_DW_TIsnd_board_lib_deps =
 	${common.M32_Pocket_board_lib_deps}
 	haklein/tlv320aic31xx@^1.0.5
+	https://github.com/oe1wkl/DisplayWrapper   ; Re-added (was removed in #157). The in-tree M32PocketLGFX
+	                                            ; replacement left the TFT dark on USB-only-powered Pockets;
+	                                            ; only the DisplayWrapper library-archive path keeps the panel
+	                                            ; alive. Root cause not yet identified — see commit log.
 	lovyan03/LovyanGFX
 M32_Pocket_build_flags =
 	-D CORE_DEBUG_LEVEL=0


### PR DESCRIPTION
## Summary

PR #157 ("Replace DisplayWrapper with direct LovyanGFX on TFT") regressed the M32 Pocket display on **USB-only-powered devices**:
- Panel stays dark
- Backlight is on
- CPU / encoder / audio / keyer all functional
- Battery-fitted Pockets are unaffected

Confirmed on Device B (no battery, USB only) — MAC `58:E6:C5:5A:E0:34`. Different USB supplies show different brief flashes at boot, then darkness, consistent with a marginal power-rail / panel-init interaction.

## Bisect

| Commit | Behaviour |
|---|---|
| `9cbeb13` V8.0 source | works ✅ |
| `b8de2c5` (#156, immediately before #157) | works ✅ |
| `1b36e44` (#157) | **dark** ❌ |
| current master | dark ❌ |
| current master + this revert | works ✅ |

## Attempted fix-forward (none worked)

Each tried on Device B with the post-#157 in-tree `LGFX` class:
- Pin LovyanGFX to `~1.1.x`
- Move `LGFX display` to its own translation unit
- Defer all panel/bus/light config from constructor to `init()`
- Re-init the display after `wifiWarmup` (the biggest current spike)
- Disable all `MorseGameMode` / `RadioCave` / `Morsel` warmups
- 200 ms delays after every spike point in `setup()`
- `cfg.bus_shared = false`
- SPI clock 40 MHz → 10 MHz
- Remove the `void display() {}` no-op shadow
- Full V8.0-style wrapper (`LGFX_Impl` + forwarding `LGFX` + `static lcd` in a dedicated TU, then again in a project-local `lib/M32PocketLGFX/`)

Only restoring `DisplayWrapper` as the actual `lib_dep` — i.e. the literal V8.0 source path — keeps the panel alive on USB-only Device B.

## Likely root cause (not 100% confirmed)

C++ static-init order. The verbose PIO link line shows:

```
[before --start-group]:
  LovyanGFX/*.o (individual)
  src/*.o        (project source, including MorseOutput.cpp.o)
[inside --start-group]:
  libESP32Encoder.a … libDisplayWrapper.a … libBLE.a
```

`DisplayWrapper.cpp.o` lives inside `libDisplayWrapper.a`, **inside the start-group**. The in-tree `M32PocketLGFX.cpp.o`, even when moved into `lib/M32PocketLGFX/`, was linked as a plain `.o` before the start-group, alongside project src. Different position → different `.init_array` slot → different static-init order. The plausible cascade is through LovyanGFX's lazy `static Panel_NULL nullobj` inside `LGFX_Device::setPanel(nullptr)` — triggered at base-class ctor time, so position-dependent.

That's a hypothesis, not a proof. Follow-up work in [issue/branch TODO] will try to force PIO to bundle `lib/M32PocketLGFX/` into a real archive and verify the link position matches DisplayWrapper's. If that works, PR #157's cleanup can stand.

## Changes

Reverts the source-level part of #157. Keeps every other post-#157 master improvement (Morsel, 8-bpp sprites, multiplayer, …).

- `MorseOutput.cpp`: `LGFX display` → `DisplayWrapper display`
- `MorseGameMode.cpp`, `MorseGame.cpp`, `MorsePileup.cpp`, `MorseRadioCave.cpp`, `MorseMorsel.cpp`: include + extern type back
- `platformio.ini`: re-add `https://github.com/oe1wkl/DisplayWrapper`

`M32PocketLGFX.h` and `IntelOneMono*.h` are left on disk (dead code) so a future fix can revisit the direct-LGFX approach without restoring all the scaffolding.

## Test plan

- [x] Build clean on `pocketwroom`
- [x] Flash on Device B (no battery, USB only) — panel lights up, splash + menu render normally
- [ ] Flash on Device A (battery installed) — confirm no regression
- [ ] Quick smoke: Keyer, Generator, Echo, Koch, Trx, Decoder, one game (Morsel or Invaders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)