### PR TITLE
Documentation: add Morsel multiplayer section to EN and DE manuals

### DIFF
--- a/Documentation/User Manual/Version 8.x/manual_de.md
+++ b/Documentation/User Manual/Version 8.x/manual_de.md
@@ -2115,6 +2115,79 @@ werden — mit einem langen Druck auf die **FN**-Taste.
   günstiger, den Fehler zu beheben als die Eingabe abzuschicken und
   es erneut zu versuchen.
 
+#### Multiplayer {-}
+
+Morsel kann auch als synchrones Mehrspieler-Match gegen andere
+M32 Pockets im gleichen Raum gespielt werden: Ein Gerät übernimmt die
+Rolle des **Servers**, beliebig viele weitere die der **Clients**.
+Alle Spieler geben dieselben 10 Wörter zeitgleich ein; am Ende
+verteilt der Server eine sortierte Rangliste, die auf allen Geräten
+zugleich erscheint.
+
+##### Mehrspieler-Spiel starten {-}
+
+Wähle nach **Games → Morsel** im ersten Bildschirm **Multiplayer**.
+Anschließend stehen zwei Rollen zur Wahl:
+
+| Rolle | Aktion |
+|-------|--------|
+| **Start as Server** | Öffnet die Server-Lobby. Stelle die Koch-Lektion mit dem Encoder und die Wortlänge mit kurzem FN-Druck ein; in der Liste erscheinen die beigetretenen Spieler, sobald sie sich verbinden. Ein Klick auf den Encoder startet das Spiel. |
+| **Join a game** | Öffnet die Client-Lobby. Sucht den Beacon eines Servers und zeigt dessen Einstellungen (Länge, Koch-Lektion, Wortanzahl), sobald einer gefunden ist. Warte, bis der Server-Bediener startet. |
+
+Ein kurzer Encoder-Druck führt zurück zur Rollenauswahl; FN lang
+beendet Morsel vollständig.
+
+Deine Kennung im Netz wird aus dem mit „Fight the Pileup" geteilten
+**Rufzeichen / Spielernamen** übernommen. Ist nichts gesetzt, wird
+automatisch eine kurze MAC-basierte Kennung verwendet — setze dein
+Rufzeichen (`playerCall`) einmalig über das M32 Configuration Tool,
+um in der Rangliste unter diesem Namen aufzuscheinen.
+
+##### Ablauf {-}
+
+Der Server wählt 10 Wörter aus dem Pool und überträgt sie an alle
+Clients; anschließend spielt jedes Gerät jedes Wort lokal mit der
+gewohnten Einzelspieler-Mechanik durch (CW-Hinweis, Paddle-Eingabe,
+farbcodiertes Ergebnis). Geschwindigkeits-Schema, Bewertung,
+Fehlerkorrektur, Inaktivitätsverhalten und Überspringen funktionieren
+identisch wie im Einzelspieler.
+
+Sobald ein Spieler die 10 Wörter abgeschlossen hat, sendet sein Gerät
+das Endergebnis (angepasste Zeit, Versuchszahl, gelöste Wörter) an
+den Server. Der Server spielt selbst als gleichberechtigter Teilnehmer
+mit — kein Host-Vorteil — und nimmt sein eigenes Ergebnis in die
+Rangliste auf.
+
+##### Ranglisten-Bildschirm {-}
+
+Sobald irgendein Spieler fertig ist, sendet der Server fortlaufend
+einen sortierten **Ranking**-Bildschirm, den alle Geräte identisch
+darstellen:
+
+| Spalte | Bedeutung |
+|--------|-----------|
+| Rang | Platz in der Wertung (1 ist am besten) |
+| Spieler | Rufzeichen oder Name |
+| Zeit | Angepasste Gesamtzeit in Sekunden |
+| Gelöst | Gelöste Wörter von 10 |
+| Versuche | Gesamtzahl der Versuche im Match |
+
+Deine eigene Zeile ist gelb hervorgehoben. Die Anzeige aktualisiert
+sich laufend, sobald weitere Spieler fertig werden; bis zu sechs
+Spitzeneinträge werden gleichzeitig angezeigt, ein `+N more`-Hinweis
+erscheint, wenn mehr Spieler ihr Ergebnis gemeldet haben. Ein
+Encoder-Klick führt zurück in die Multiplayer-Lobby; ein langer Druck
+verlässt Morsel.
+
+##### Hinweise zum Funkverkehr {-}
+
+Das Protokoll ist **ESP-NOW-Broadcast** auf einem festen Kanal —
+weder ein Router noch Internet oder ein Pairing-Vorgang sind nötig;
+alle Geräte in Funkreichweite empfangen einander direkt. Die weiche
+Obergrenze liegt bei **20 Spielern** pro Match. Ein Client, der die
+Verbindung zum Server verliert, wird nach etwa 8 Sekunden aus der
+angezeigten Rangliste entfernt.
+
 ## WiFi Functions
 
 Neben der WiFi-Transceiver-Funktionalität kannst du die WLAN-Funktion

--- a/Documentation/User Manual/Version 8.x/manual_en.md
+++ b/Documentation/User Manual/Version 8.x/manual_en.md
@@ -1928,6 +1928,47 @@ You can also reach the high-score table from the lobby at any time with a long p
 
 - Backspace freely (`<err>` = 8 dits) — the timer keeps running, but a wrong submitted guess costs you 5 s, so it's almost always cheaper to fix the mistake than to submit and try again.
 
+#### Multiplayer {-}
+
+Morsel can also be played as a synchronised multi-player match against other M32 Pockets in the same room, with one device acting as the **server** and any number of others as **clients**. Every player keys the same 10 words at the same time, and at the end the server broadcasts a ranked score table that every device shows simultaneously.
+
+##### Starting a Multiplayer Game {-}
+
+After choosing **Games → Morsel**, pick **Multiplayer** at the first screen. You can then choose:
+
+| Role | Action |
+|------|--------|
+| **Start as Server** | Opens the server lobby. Adjust the Koch lesson with the encoder and the word length with FN short press; the displayed list shows joined players as they connect. Click the encoder to start the game. |
+| **Join a game** | Opens the client lobby. Searches for a server's broadcast and shows its settings (length, Koch lesson, word count) once one is found. Wait for the server operator to start. |
+
+A short press of the encoder returns to the role picker; FN long press exits Morsel.
+
+Your identity on the network is taken from the **call sign / player name** shared with Fight the Pileup. If neither is set yet, a short MAC-derived tag is used automatically — set your call sign (`playerCall`) once via the M32 Configuration Tool to appear under it in the ranking.
+
+##### Playing {-}
+
+The server picks 10 words from the pool and broadcasts them to all clients; every device then plays each word locally with the normal single-player engine (CW clue, paddle entry, colour-coded result). The clue speed schedule, scoring rules, error correction, idle handling and skip behaviour are all identical to single-player.
+
+When a player finishes the 10-word match, their device sends its final score (adjusted time, guess count, words solved) to the server. The server competes as a regular player — no host advantage — and includes its own score in the ranking.
+
+##### Ranking Screen {-}
+
+Once any player has finished, the server starts broadcasting a sorted **Ranking** screen which all devices render identically:
+
+| Column | Meaning |
+|--------|---------|
+| Rank | Position in the standings (1 is best) |
+| Player | Call sign or name |
+| Time | Total adjusted time in seconds |
+| Solved | Words solved out of 10 |
+| Guesses | Total guesses across the match |
+
+Your own row is highlighted in yellow. The screen updates live as more players finish; up to six top entries are shown on screen and a `+N more` indicator appears if more players have reported. Click the encoder to return to the multiplayer lobby; a long press exits Morsel.
+
+##### Networking Notes {-}
+
+The protocol is **ESP-NOW broadcast** on a fixed channel — no router, internet, or pairing is needed; all devices in radio range simply hear each other. The soft cap is **20 players** per match. A device that loses contact with the server is dropped from the displayed ranking after about 8 seconds.
+
 ## WiFi Functions
 
 Apart from the functionality of WiFi Transceiver, you can use the WiFi


### PR DESCRIPTION
## Summary

- The existing Morsel section in both manuals only covered single-player. Adds a Multiplayer subsection at the end of each, in matching house style.
- Covers: mode/role picker, server lobby (Koch + word length + joined roster), client lobby (server discovery + settings display), identity reuse from Fight the Pileup, in-game flow (server broadcasts 10 words, every device runs the unchanged single-player engine), the unified live-updating ranking screen with own-row highlight and `+N more` indicator, and ESP-NOW networking notes (no router, 20-player soft cap, 8 s timeout).
- Source-only — PDFs regenerate via `Version 8.x/build.sh` per the existing convention.

## Test plan

- [x] Markdown renders correctly (heading levels, tables, `{-}` TOC-suppression markers match the rest of the file).
- [ ] Optional: run `Version 8.x/build.sh` to regenerate the PDF and visually skim the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)