### PR TITLE
Add VK/ZL region option for callsign generator

### DIFF
--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -202,11 +202,11 @@ parameter MorsePreferences::pliste[] = {
     {"Unlimited", "3", "4", "5", "6"}
   },
   {
-    0, 0, 6, 1,                                                 // Generators: continent for generated call signs   0 = all, 1-6 = specific continents
+    0, 0, 7, 1,                                                 // Generators: continent for generated call signs   0 = all, 1-6 = specific continents, 7 = VK/ZL only
     "Calls Region",
     "Continent(s) for generated call signs",
     true,
-    {"All", "Europe", "N America", "S America", "Africa", "Asia", "Oceania" }
+    {"All", "Europe", "N America", "S America", "Africa", "Asia", "Oceania", "VK/ZL" }
   },
   {
     1, 0, 1, 1,                                                 // Generators: only generate common call signs?   0 = no, 1 = yes

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -1722,9 +1722,11 @@ String getRandomCall(int maxLength) {
     static char call[16];
     int pos = 0;
     uint8_t contMask;
+    uint8_t contPref = MorsePreferences::pliste[posCallContinent].value;
+    bool vkzlOnly = (contPref == 7);
     // Get filter settings
     if (maxLength != 1)     /// means the max call length is not 3 
-        contMask = getContinentMask(MorsePreferences::pliste[posCallContinent].value);
+        contMask = vkzlOnly ? CONT_OC : getContinentMask(contPref);
     else                    /// maxLength == 1 means we want a 3-character call; these only exist in NA and EU, so we include those two.
         contMask = CONT_ALL;
     bool commonOnly  = (MorsePreferences::pliste[posCallCommon].value == 1);
@@ -1745,6 +1747,7 @@ String getRandomCall(int maxLength) {
         if (!(cont & contMask)) continue;
         if (weight < minWeight) continue;
         if ((int)strlen(pfxBuf) > maxPfxLen) continue;
+        if (vkzlOnly && strncmp(pfxBuf, "VK", 2) != 0 && strncmp(pfxBuf, "ZL", 2) != 0) continue;
         totalWeight += weight;
     }
  
@@ -1770,6 +1773,7 @@ String getRandomCall(int maxLength) {
         if (!(cont & contMask)) continue;
         if (weight < minWeight) continue;
         if ((int)strlen(pfxBuf) > maxPfxLen) continue;
+        if (vkzlOnly && strncmp(pfxBuf, "VK", 2) != 0 && strncmp(pfxBuf, "ZL", 2) != 0) continue;
         cumulative += weight;
         if (cumulative > pick) {
             chosen = i;


### PR DESCRIPTION
Adds a "VK/ZL" option (value 7) to the Calls Region setting in the callsign generator. This allows Australian and New Zealand operators to practice with locally relevant callsigns rather than the broader Oceania region.
Changes:

- MorsePreferences.cpp: added "VK/ZL" as 8th option in Calls Region menu
- m32_v6.ino: filter prefix selection to VK and ZL prefixes when option is selected, using existing weights from the prefix table