### PR TITLE
Pileup multiplayer P2: beacon TX + ESP-NOW /ftp/ RX transport

### DIFF
--- a/Software/src/Version 6 and newer/MorsePileup.cpp
+++ b/Software/src/Version 6 and newer/MorsePileup.cpp
@@ -323,10 +323,65 @@ static const char* getPlayerIdent() {
     return ftp.useCallsign ? ftp.playerCall : ftp.playerName;
 }
 
-//=== Networking stubs — real networking in Phase 3 ===
+//=== Networking — plain-text /ftp/ packets over ESP-NOW broadcast ===
+//
+// Wire format (Option A from the handoff): human-readable, pipe-delimited
+// ASCII so it is trivially parseable and debuggable. P2 implements the
+// beacon TX path and the RX *transport* (a lock-free-ish ring filled by the
+// ESP-NOW callback, drained by the lobby loop). P3 fills in the parsing and
+// roster update inside checkReceivedMessages().
+//
+//   /ftp/B|<ident>|<lives>|<score>|<inPileup>    Beacon (every 5 s)
 
-static void sendBeacon() { ftp.lastBeaconSent = millis(); }
-static void checkReceivedMessages() {}
+#define FTP_RX_RING   8
+#define FTP_RX_MAX    80          // keep packets well under the 250 B ESP-NOW cap
+
+// Producer = ESP-NOW RX callback (ftpNetOnRecv); consumer = lobby/game loop.
+struct FtpRx { uint8_t len; char d[FTP_RX_MAX]; };
+static volatile FtpRx   ftpRxRing[FTP_RX_RING];
+static volatile uint8_t ftpRxHead = 0, ftpRxTail = 0;
+
+// RX callback context — do the minimum: copy bytes, advance head, return.
+// No parsing, no String, no Serial here (constraint #1 / ISR safety).
+void MorsePileup::ftpNetOnRecv(const uint8_t* mac, const uint8_t* data, uint8_t len) {
+    (void)mac;
+    uint8_t h = ftpRxHead;
+    uint8_t nxt = (h + 1) % FTP_RX_RING;
+    if (nxt == ftpRxTail) return;                       // ring full: drop
+    uint8_t n = (len < FTP_RX_MAX) ? len : (FTP_RX_MAX - 1);
+    memcpy((void*)ftpRxRing[h].d, data, n);
+    ftpRxRing[h].d[n] = '\0';
+    ftpRxRing[h].len = n;
+    ftpRxHead = nxt;
+}
+
+// Broadcast a beacon. Called from the lobby idle frame every FTP_BEACON_INTERVAL.
+static void sendBeacon() {
+    ftp.lastBeaconSent = millis();
+    char buf[FTP_RX_MAX];
+    int n = snprintf(buf, sizeof(buf), "%sB|%s|%u|%lu|%d",
+                     FTP_MAGIC, getPlayerIdent(),
+                     (unsigned)ftp.lives, (unsigned long)ftp.score,
+                     (ftp.state == FTP_PILEUP) ? 1 : 0);
+    if (n > 0)
+        quickEspNow.send(ESPNOW_BROADCAST_ADDRESS, (uint8_t*)buf, (size_t)n);
+}
+
+// Drain the RX ring on an idle lobby frame.
+// P2: prove the transport by echoing each received /ftp/ line to serial.
+// P3 replaces this print with type-dispatch + roster update.
+static void checkReceivedMessages() {
+    while (ftpRxTail != ftpRxHead) {
+        uint8_t t = ftpRxTail;
+        uint8_t len = ftpRxRing[t].len;
+        if (len >= FTP_RX_MAX) len = FTP_RX_MAX - 1;
+        char line[FTP_RX_MAX];
+        memcpy(line, (const void*)ftpRxRing[t].d, len);
+        line[len] = '\0';
+        ftpRxTail = (t + 1) % FTP_RX_RING;
+        Serial.println(String("FTP RX: ") + line);     // P2 verification (temporary)
+    }
+}
 
 //=== Player roster ===
 

--- a/Software/src/Version 6 and newer/MorsePileup.h
+++ b/Software/src/Version 6 and newer/MorsePileup.h
@@ -132,6 +132,12 @@ struct FtpGameData {
 // ---- Public interface ----
 namespace MorsePileup {
     void run();
+
+    // Called from onEspnowRecv() for broadcast /ftp/ packets while pileupMode
+    // is set. Runs in the ESP-NOW RX callback context: it only copies the
+    // packet into a ring buffer and returns; the lobby/game loop drains and
+    // parses it (see checkReceivedMessages()).
+    void ftpNetOnRecv(const uint8_t* mac, const uint8_t* data, uint8_t len);
 }
 
 #endif  // CONFIG_CW_GAME

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -2951,6 +2951,18 @@ void onEspnowRecv(const uint8_t* mac, const uint8_t* data, uint8_t len, signed i
     }
     #endif
 
+    // Fight the Pileup multiplayer: intercept its plain-text /ftp/ packets
+    // (beacons, attacks, ...). Must run BEFORE the MOPP branch below, or a
+    // /ftp/ packet would be mis-decoded as CW elements. Callback context:
+    // hand off to a copy-and-return ring filler, do not parse here.
+    #ifdef CONFIG_CW_GAME
+    if (pileupMode && broadcast && len >= FTP_MAGIC_LEN &&
+        memcmp(data, FTP_MAGIC, FTP_MAGIC_LEN) == 0) {
+        MorsePileup::ftpNetOnRecv(mac, data, len);
+        return;
+    }
+    #endif
+
     // Pileup game: intercept and decode MOPP packet to text
     #ifdef CONFIG_CW_GAME
     if (pileupMode && len > 2 && broadcast) {


### PR DESCRIPTION
## Summary

Step 2 of the Fight-the-Pileup multiplayer build. Implements the beacon **send** path and the plain-text `/ftp/` packet **transport** over ESP-NOW broadcast (Option A from the handoff). No roster/parse semantics yet — that lands in P3.

> **Stacked on #178** (P1). Base branch is `claude/pileup-mp-p1`; this PR's diff is P2-only. Will retarget to `master` once #178 merges.

Wire format (human-readable, pipe-delimited ASCII):

```
/ftp/B|<ident>|<lives>|<score>|<inPileup>    Beacon (every 5 s)
```

- **`sendBeacon()`** — was a no-op timestamp stub; now `snprintf`-builds the beacon and broadcasts it. Already called every `FTP_BEACON_INTERVAL` from the lobby idle frame.
- **RX transport** mirrors `MorseMorsel`'s ISR-safe ring: `ftpNetOnRecv()` (new `MorsePileup` namespace entry) copies the packet into a `volatile` ring and returns — no parsing, no `String`, no `Serial` in the callback. This is the **permanent** mechanism; P3 only adds dispatch on top.
- **`onEspnowRecv()`** (`m32_v6.ino`) gets a `/ftp/` branch placed **before** the existing MOPP branch, so a `/ftp/` packet is never mis-decoded as CW elements.
- **`checkReceivedMessages()`** — drains the ring and echoes each line to serial as `FTP RX: ...`. Temporary P2 verification; P3 replaces it with type-dispatch + roster update.

Everything is lobby-scoped on both TX and RX; `statePileup()` and the keyer tight loop are untouched, so keyer timing cannot regress.

`+648 B` RAM (the 8×81 B ring), `+756 B` flash on `pocketwroom`.

## Test plan

Tested on two M32 Pockets on the same ESP-NOW channel:

- [x] Both enter Pileup → MULTIPLAYER; monitored device prints the other's beacon `FTP RX: /ftp/B|OE1WKL|3|0|0` ~every 5 s
- [x] UI still shows `Searching...` (roster wiring is P3 — expected)
- [x] Clean exit, no reboot (P1 teardown intact)

## Note for P3

Roster is specified ident-keyed, so two devices sharing a callsign collapse to one row. Decide MAC-keyed vs. distinct-ident in P3 — `ftpNetOnRecv` already receives `mac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)