### PR TITLE
Pileup P6a: live roster during the pileup

### DIFF
--- a/Software/src/Version 6 and newer/MorsePileup.cpp
+++ b/Software/src/Version 6 and newer/MorsePileup.cpp
@@ -1078,6 +1078,21 @@ static void drawPileupHUD() {
         canvas->drawString(buf, FTP_W - 4, 26);
         canvas->setTextDatum(lgfx::top_left);
     }
+
+    // Multiplayer: a compact live strip of opponents — "IDENT:lives", green
+    // while alive, dimmed once eliminated. Their lives update from beacons.
+    if (!ftp.singlePlayer) {
+        canvas->setFont(&fonts::Font0);
+        int x = 4;
+        for (int i = 0; i < FTP_MAX_PLAYERS && x < FTP_W - 34; i++) {
+            if (!ftp.players[i].active) continue;
+            char ob[16];
+            snprintf(ob, sizeof(ob), "%s:%d", ftp.players[i].ident, ftp.players[i].lives);
+            canvas->setTextColor(ftp.players[i].eliminated ? FTP_DIM : FTP_OK, FTP_BG);
+            canvas->drawString(ob, x, 26);
+            x += canvas->textWidth(ob) + 6;
+        }
+    }
 }
 
 static void drawDefendArea() {
@@ -1399,6 +1414,13 @@ static void statePileup() {
         // Not while an attack pause is active: callers enqueued during the pause
         // would be wrongly time-shifted on resume. They wait in the ring instead.
         if (!ftp.singlePlayer && !attackMode) checkReceivedMessages();
+
+        // Keep the roster live during the game: beacon our own state (lives/score,
+        // inPileup = 1) so peers can track us, and age out peers that went silent.
+        if (!ftp.singlePlayer) {
+            if (millis() - ftp.lastBeaconSent >= FTP_BEACON_INTERVAL) sendBeacon();
+            updateRoster();
+        }
 
         // --- Earned-attack mode: after a correct defend the pileup pauses and the
         //     player keys ONE attack. No spawning / no timeouts while it is up. ---


### PR DESCRIPTION
## Summary

Foundation for P6b (elimination/winner): the roster is now **live during a game**, not just a lobby snapshot.

- **Beacon during the pileup:** every `FTP_BEACON_INTERVAL` on an idle frame, broadcast our own `/ftp/B` (lives, score, `inPileup=1`) so peers can track us. Idle-only, like attacks.
- **Age the roster during the pileup** (`updateRoster` each idle frame), so a peer that goes silent (powered off / left) drops after the TTL.
- **Compact opponents strip** in the pileup HUD: each active peer as `IDENT:lives`, green while alive and dimmed once eliminated; lives update in real time from beacons.

All multiplayer-gated (`!ftp.singlePlayer`); single-player untouched.

Built for **both** variants (`pocketwroom` + `heltec_wifi_lora_32_V2`) per CLAUDE.md §1.

## Test plan
Tested on two M32 Pockets: each device shows the other in the pileup and its lives tick down live as it takes damage; a powered-off peer ages out.

## Next: P6b
Elimination (`/ftp/X` on death) + last-player-standing among in-pileup non-eliminated peers + winner (`/ftp/W`) + shared winner screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)