### PR TITLE
Fix VBand BT brackets bug

### DIFF
--- a/Software/src/Version 6 and newer/MorseBluetooth.cpp
+++ b/Software/src/Version 6 and newer/MorseBluetooth.cpp
@@ -252,7 +252,7 @@ void MorseBluetooth::bluetoothTypeCharacter(const char chr)
 		uint8_t val = (uint8_t)chr;
 		if (val > KEYMAP_SIZE)
 			return; // character not available on keyboard - skip
-		KEYMAP map = keymap[chr];
+		KEYMAP map = keymap[(uint8_t)chr];
 
 		// create input report
 		InputReport report = {
@@ -273,6 +273,12 @@ void MorseBluetooth::bluetoothTypeCharacter(const char chr)
 		input->setValue((uint8_t *)&NO_KEY_PRESSED, sizeof(NO_KEY_PRESSED));
 		input->notify();
 	}
+}
+
+void MorseBluetooth::bluetoothTypeVbandElement(char c)
+{
+	if (isBleConnected)
+		bluetoothTypeCharacter(c);
 }
 
 // Emit a Shift+Enter HID report (soft return in word processors / chat apps).

--- a/Software/src/Version 6 and newer/MorseBluetooth.h
+++ b/Software/src/Version 6 and newer/MorseBluetooth.h
@@ -25,6 +25,7 @@ namespace MorseBluetooth
 	void stopBluetooth(void);
 	void bluetoothTypeLCTRL(bool ctrl);
 	void bluetoothTypeCharacter(const char chr);
+	void bluetoothTypeVbandElement(char c);
 	void bluetoothTypeString(const String& str);
 };
 

--- a/Software/src/Version 6 and newer/MorseDecoder.cpp
+++ b/Software/src/Version 6 and newer/MorseDecoder.cpp
@@ -15,6 +15,9 @@
 #include "goertzel.h"
 #include "MorseDecoder.h"
 #include "MorseOutput.h"
+#ifdef CONFIG_BLUETOOTH_KEYBOARD
+#include "MorseBluetooth.h"
+#endif
 
 extern unsigned long genTimer;      /// needed for echo trainer
 extern morserinoMode morseState;
@@ -194,6 +197,10 @@ void Decoder::OFF_() {                                 /// what we do when we ju
             recalculateDit(highDuration);
             if (morseState == loraTrx || morseState == wifiTrx)
                 cwForTx(1);
+#ifdef CONFIG_BLUETOOTH_KEYBOARD
+            if ((MorsePreferences::pliste[posBluetoothOut].value & 0x1) == 0x1 && fromKey)
+                MorseBluetooth::bluetoothTypeCharacter('[');
+#endif
       }
       else  {        /// we got a dah
             myTable.recordDah();
@@ -201,6 +208,10 @@ void Decoder::OFF_() {                                 /// what we do when we ju
             recalculateDah(highDuration);
             if (morseState == loraTrx || morseState == wifiTrx)
                 cwForTx(2);
+#ifdef CONFIG_BLUETOOTH_KEYBOARD
+            if ((MorsePreferences::pliste[posBluetoothOut].value & 0x1) == 0x1 && fromKey)
+                MorseBluetooth::bluetoothTypeCharacter(']');
+#endif
       }
   }
   keyOut(false, fromKey, 0, 0);

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -235,6 +235,9 @@ KEYERSTATES keyerState;
 unsigned long charCounter = 25; // we use this to count characters after changing speed - after n characters we decide to write the config into NVS
 uint8_t sensor;                 // what we read from checking the touch sensors
 boolean leftKey, rightKey;
+#ifdef CONFIG_BLUETOOTH_KEYBOARD
+static char bluetoothVbandKeyChar = 0;
+#endif
 
 
 unsigned long interWordTimer = 0;      // timer to detect interword spaces
@@ -1381,6 +1384,9 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                              curtistimer = ditLength;        // no early paddle checking in Curtis mode A, U oder Non-squeeze
                              break;
             }
+#ifdef CONFIG_BLUETOOTH_KEYBOARD
+            bluetoothVbandKeyChar = '[';
+#endif
             keyerState = KEY_START;                          // set next state of state machine
             break;
 
@@ -1402,6 +1408,9 @@ boolean doPaddleIambic (boolean dit, boolean dah) {
                              curtistimer = dahLength;        // no early paddle checking in Curtis mode A,  oder Non-squeeze
                              break;
             }
+#ifdef CONFIG_BLUETOOTH_KEYBOARD
+            bluetoothVbandKeyChar = ']';
+#endif
             keyerState = KEY_START;                          // set next state of state machine
             break;
 
@@ -2648,13 +2657,15 @@ void changeVolume( int t) {
 }
 
 void keyTransmitter(boolean noTx) {
-  if (noTx )
+#ifdef CONFIG_BLUETOOTH_KEYBOARD
+   if ((MorsePreferences::pliste[posBluetoothOut].value & 0x1) == 0x1 && bluetoothVbandKeyChar != 0) {
+      MorseBluetooth::bluetoothTypeVbandElement(bluetoothVbandKeyChar);
+      bluetoothVbandKeyChar = 0;
+   }
+#endif
+   if (noTx)
       return;
    digitalWrite(keyerPin, HIGH);           // turn the LED on, key transmitter, or whatever
-#ifdef CONFIG_BLUETOOTH_KEYBOARD
-   if ((MorsePreferences::pliste[posBluetoothOut].value & 0x1) == 0x1)
-      MorseBluetooth::bluetoothTypeLCTRL(true);
-#endif
 }
 
 
@@ -3359,8 +3370,7 @@ void keyOut(boolean on,  boolean fromHere, int f, int volume) {
         }
         digitalWrite(keyerPin, LOW);      // stop keying Tx
 #ifdef CONFIG_BLUETOOTH_KEYBOARD
-        if ((MorsePreferences::pliste[posBluetoothOut].value & 0x1) == 0x1)
-          MorseBluetooth::bluetoothTypeLCTRL(false);
+        bluetoothVbandKeyChar = 0;
 #endif
   }   // end key off
 }


### PR DESCRIPTION
As [ and ] were not coming through at all via Vband Keying some changes were necessary. This is working now with https://hamradio.solutions/vband/ 

In Vband settings just choose Iambic Keyer mode when that is the way you work with Morserino.

I see no timing problems: the sound from the Morserino and the PC are at the same time.

Tested with Morserino-32 V2 on MacOS 26.5.1.