### PR TITLE
Fix Custom Chars silently reset by any preferences-menu exit

### DIFF
--- a/Documentation/Protocol Description/M32 Protocol.md
+++ b/Documentation/Protocol Description/M32 Protocol.md
@@ -546,12 +546,14 @@ Example:
 
 	PUT customchars/set/mkrsuaptlowi
 
-Note: on the device, the custom character set is derived from the uploaded
-player file (`/player.txt`) — that file is the source of truth. A set injected
-with this command therefore persists only until the preferences menu is next
-exited while "Custom Chars" is active: at that moment the set is re-derived
-from the player file, replacing the injected one. To make a character set
-permanent, upload it as the player file instead (or in addition).
+Note: on the device, the custom character set can also be derived from the
+uploaded player file (`/player.txt`). A set injected with this command persists
+across preferences-menu visits and stays active until explicitly replaced — it
+is *not* overwritten by exiting the preferences menu. It is only re-derived
+from the player file when "Koch Sequence" is explicitly (re-)selected to
+"Custom Chars" (via the on-device menu, or via `PUT config/koch sequence/4`),
+so uploading a new player file and then re-selecting "Custom Chars" is how you
+load its content, overwriting anything injected with this command.
 
 `PUT customchars/clear`
 

--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -1319,7 +1319,7 @@ boolean MorsePreferences::adjustKeyerPreference(prefPos pos) {        /// rotati
                       pliste[pos].value = (temp % (maxi - mini +vstep)) + mini;
                   }
                   if (pos == posKochSeq) {
-                      if (!MorsePreferences::handleKochSequence()) {
+                      if (!MorsePreferences::handleKochSequence(true)) {    // explicit on-device (re-)selection: force a file reload
                           MorseOutput::printOnScroll(2, BOLD, 0, "No custom set");
                           delay(700);
                       }
@@ -1408,10 +1408,15 @@ boolean MorsePreferences::adjustKeyerPreference(prefPos pos) {        /// rotati
 }   // end of function adjustKeyerPreference
 
 
-boolean MorsePreferences::handleKochSequence() {  // returns false if Custom Chars was requested but no character set is available (yet)
+boolean MorsePreferences::handleKochSequence(boolean forceReload) {  // returns false if Custom Chars was requested but no character set is available (yet)
     MorsePreferences::useCustomChars = false;
     if (MorsePreferences::pliste[posKochSeq].value == 4) {      // Custom Chars
-        String chars = MorsePreferences::customCharSet;
+        // forceReload (set by an explicit on-device/serial re-selection of Custom
+        // Chars) always re-reads the file player, so uploading a new player.txt and
+        // re-selecting Custom Chars reloads it, per the documented workflow
+        // (manual_en.md/manual_de.md §5.4.1). Boot/snapshot recall pass the default
+        // (false) and keep the already-loaded set untouched.
+        String chars = (forceReload) ? "" : MorsePreferences::customCharSet;
         if (chars.length() == 0)
             chars = getCustomChars();                            // try to (re-)read it from the file player right away
         if (chars.length() == 0)

--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -788,7 +788,16 @@ boolean MorsePreferences::setupPreferences(uint8_t atMenu) {
                       break;
           case -1:    //////// long press indicates we are done with setting preferences - check if we need to store some of the preferences
 
-          exitFromHere: if (MorsePreferences::useCustomChars) {
+          exitFromHere: if (MorsePreferences::useCustomChars && MorsePreferences::customCharSet.length() == 0) {
+                            // Bootstrap only: pull from the file player exclusively when no
+                            // custom set is active yet (mirrors handleKochSequence()'s guard).
+                            // Previously ran unconditionally on every preferences exit, which
+                            // silently replaced an already-active custom set (however it was
+                            // set - on-device, the web tool's direct text field, ...) with
+                            // whatever /player.txt currently contains, even when the exit was
+                            // triggered by an unrelated preference change. Found via user
+                            // testing: exiting after changing Interword Space alone discarded
+                            // a working custom sequence.
                             String chars = getCustomChars(); //// get custom characters
                             if (chars.length() > 0)
                                 koch.setCustomChars(chars);

--- a/Software/src/Version 6 and newer/MorsePreferences.h
+++ b/Software/src/Version 6 and newer/MorsePreferences.h
@@ -247,7 +247,7 @@ namespace MorsePreferences
   void createKochWords(uint8_t maxl, uint8_t koch);
   uint8_t wordIsKoch(String thisWord);
   void createKochAbbr(uint8_t maxl, uint8_t koch);
-  boolean handleKochSequence();
+  boolean handleKochSequence(boolean forceReload = false);   // forceReload: re-read Custom Chars from the file player even if a set is already active - used for an explicit (re-)selection of Custom Chars, e.g. after uploading a new player.txt
   void handleCarouselChange();
   void setCustomChars(String);
   //void kochSetup();

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -4392,7 +4392,7 @@ boolean setParameter(String token, String value) {      // change a parameter, r
 
 
       if (i == posKochSeq)
-            MorsePreferences::handleKochSequence();
+            MorsePreferences::handleKochSequence(true);    // explicit serial (re-)selection: force a file reload
       else if (i == posCarouselStart)
             MorsePreferences::handleCarouselChange();
 #ifdef CONFIG_SOUND_I2S


### PR DESCRIPTION
### Summary
- **The bug:** When the Koch Trainer's "Custom Chars" character set is active, exiting the preferences menu for *any* reason — even changing an unrelated setting like Interword Space — silently replaced the active custom character sequence with whatever text is currently uploaded to the file player, discarding whatever sequence was actually in use.
- **Root cause:** `setupPreferences()`'s exit handler unconditionally re-derives the custom set from `/player.txt` via `getCustomChars()` whenever `useCustomChars` is true, regardless of what was actually changed. This should only happen when the user explicitly re-selects "Custom Chars" as the Koch Sequence value (as documented in the manual) — which is exactly what `handleKochSequence()` already does correctly elsewhere, falling back to the file only when no custom set is active yet.
- **The fix:** Bring the preferences-exit handler in line with `handleKochSequence()`'s existing guard — only pull from the file player when `customCharSet` is currently empty (bootstrap case), never overwriting an already-active set just because the user exited preferences for an unrelated reason.
- Found and reported by Christian Konecny while testing an unrelated branch.

### Test plan
- [x] Builds clean: `heltec_wifi_lora_32_V2`, `pocketwroom`
- [x] Reproduced on physical M32 Pocket hardware: set a custom sequence, changed Interword Space, exited preferences — sequence was replaced with file-player content
- [x] Confirmed fixed with the same steps after the patch — sequence preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)