### PR TITLE
CW Generator: wrap display at word boundaries, not mid-word

### DIFF
--- a/Software/src/Version 6 and newer/MorseOutput.cpp
+++ b/Software/src/Version 6 and newer/MorseOutput.cpp
@@ -82,6 +82,7 @@ char textBuffer[NoOfLines][2 * NoOfCharsPerLine + 1]; /// we need extra room for
 
 uint8_t linePointer = 0;    /// defines the current bottom line
 uint8_t bottomLine = 0;
+static uint8_t scrollScreenPos = 0;   /// current column on the scroll line; used by printToScroll_internal() and by wordNeedsWrap()
 
 const int8_t MorseOutput::maxPos = NoOfLines - NoOfVisibleLines;
 int8_t MorseOutput::relPos = MorseOutput::maxPos;
@@ -809,7 +810,6 @@ void MorseOutput::printToScroll_internal(FONT_ATTRIB style, const String& text, 
   //unsigned char ch;
   //
   static uint8_t pos = 0;
-  static uint8_t screenPos = 0;
   static FONT_ATTRIB lastStyle = REGULAR;
   uint8_t l = text.length();
   if (l == 0) {                               // an empty string signals we should clear the buffer
@@ -817,7 +817,7 @@ void MorseOutput::printToScroll_internal(FONT_ATTRIB style, const String& text, 
       textBuffer[i][0] = (char) 0;                    /// empty this line
     }
     refreshScrollArea((NoOfLines + bottomLine - (NoOfVisibleLines - 1)) % NoOfLines);
-    pos = screenPos = 0;                                // reset the position pointers
+    pos = scrollScreenPos = 0;                                // reset the position pointers
     return;
   }
 
@@ -831,19 +831,19 @@ void MorseOutput::printToScroll_internal(FONT_ATTRIB style, const String& text, 
   }
 
 #ifdef CONFIG_TFT
-  int textTooLong = (screenPos + l > display.getWidth()/display.getStringWidth("A"));
+  int textTooLong = (scrollScreenPos + l > display.getWidth()/display.getStringWidth("A"));
 #else
-  int textTooLong = (screenPos + l > NoOfCharsPerLine);
+  int textTooLong = (scrollScreenPos + l > NoOfCharsPerLine);
 #endif
 
   if (textTooLong) {                 // we need to scroll up and start a new line
     MorseOutput::newLine(scroll);
-    pos = 0;  screenPos = 0; lastStyle = REGULAR;
+    pos = 0;  scrollScreenPos = 0; lastStyle = REGULAR;
   }
 
 #ifdef CONFIG_TFT
   // After a wrap to a new line, discard a leading space (word-wrap artefact, LCD only)
-  if (screenPos == 0 && l > 0 && stripped[0] == ' ') {
+  if (scrollScreenPos == 0 && l > 0 && stripped[0] == ' ') {
     stripped.remove(0, 1);
     l = stripped.length();
   }
@@ -901,14 +901,34 @@ void MorseOutput::printToScroll_internal(FONT_ATTRIB style, const String& text, 
   if (relPos == maxPos) {                                     // we show the bottom lines on the screen, therefore we add the new stuff  immediately
     /// and send string to screen, avoiding refresh of complete line
     //DEBUG("relPos: " + String(relPos));
-    MorseOutput::printOnScroll(NoOfVisibleLines - 1, style, screenPos, t);               // these characters are 9 pixels wide,
+    MorseOutput::printOnScroll(NoOfVisibleLines - 1, style, scrollScreenPos, t);               // these characters are 9 pixels wide,
   }
   display.setFont(DialogInput_plain_15);;
-  screenPos += (display.getStringWidth(t) / C_WIDTH);
+  scrollScreenPos += (display.getStringWidth(t) / C_WIDTH);
   if (linebreak) {
     MorseOutput::newLine(scroll);
-    pos = 0;  screenPos = 0; lastStyle = REGULAR;
+    pos = 0;  scrollScreenPos = 0; lastStyle = REGULAR;
   }
+}
+
+/// Query only, no side effects: would displaying `wordLen` more columns of
+/// text overflow the current scroll line? Used by the CW Generator to
+/// decide, before it starts revealing a word character-by-character,
+/// whether to wrap at the word boundary instead of relying on
+/// printToScroll_internal's per-character wrap (which only sees one token
+/// at a time and so cannot avoid splitting a word). Only makes sense for a
+/// generator, which already knows the whole word up front (in clearText)
+/// before showing its first character; live keyed/decoded input has no such
+/// look-ahead, so it still relies on the plain per-character wrap.
+/// Returns false (no point wrapping) if the line is already empty, since a
+/// word too wide for one whole line has to hard-wrap somewhere regardless.
+boolean MorseOutput::wordNeedsWrap(uint16_t wordLen) {
+#ifdef CONFIG_TFT
+  uint16_t width = display.getWidth() / display.getStringWidth("A");
+#else
+  uint16_t width = NoOfCharsPerLine;
+#endif
+  return (scrollScreenPos > 0) && (scrollScreenPos + wordLen > width);
 }
 
 

--- a/Software/src/Version 6 and newer/MorseOutput.h
+++ b/Software/src/Version 6 and newer/MorseOutput.h
@@ -57,6 +57,7 @@ namespace MorseOutput
   uint8_t printOnScroll(uint8_t line, FONT_ATTRIB how, uint8_t xpos, const String& mystring, boolean small = false);
   void printToScroll(FONT_ATTRIB style, const String& text, boolean autoflush, boolean scroll);
   void printToScroll_internal(FONT_ATTRIB style, const String& text, boolean scroll);
+  boolean wordNeedsWrap(uint16_t wordLen);
   void clearScrollLines();
   void clearLine(uint8_t line);
   void clearScrollBuffer();

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -2232,6 +2232,22 @@ void dispGeneratedChar() {
             (morseState == loraTrx || morseState == wifiTrx || morseState == morseGenerator || playCW)) ||
             (morseState == echoTrainer && MorsePreferences::pliste[posEchoDisplay].value != CODE_ONLY))
     {
+        // CW Generator only: clearText still holds the rest of the current
+        // word (up to the next space), so -- unlike live keyed/decoded
+        // input, where we only find out a word is finished once it's over
+        // -- its length is already known before the first character is
+        // shown. Use that to wrap pre-emptively at the word boundary
+        // instead of leaving it to MorseOutput's per-character wrap, which
+        // only ever sees one token at a time and so can split a word across
+        // lines. Echo Trainer / Trx / LoRa / WiFi playback are untouched.
+        if (morseState == morseGenerator) {
+            int nextSpace = clearText.indexOf(' ');
+            uint16_t wordLen = (uint16_t) ((nextSpace == -1) ? clearText.length() : nextSpace);
+            if (MorseOutput::wordNeedsWrap(wordLen)) {
+                displayGeneratedMorse(REGULAR, "\n");
+            }
+        }
+
         if (clearText.charAt(0) == (char)0xC3) {           // UTF-8 two-byte char
             charBuf[0] = clearText.charAt(0);
             charBuf[1] = clearText.charAt(1);


### PR DESCRIPTION
## Summary

- Wraps the scroll display's line breaks at word boundaries for the CW
  Generator (`morseState == morseGenerator`), instead of breaking wherever
  the character count happens to run out — a group like "excc" no longer
  gets split as "exc" / "c" across two lines.
- Scoped exclusively to `morseState == morseGenerator` (covers both direct
  CW Generator and Koch Trainer → CW Generator, since both drive this
  state) via a small addition in `dispGeneratedChar()` (`m32_v6.ino`): it
  looks ahead in `clearText` — which already holds the rest of the current
  word — to check whether the word fits the remaining line width, and
  forces a line break beforehand if not.
- Echo Trainer, CW Keyer, decoded-audio display, Transceiver (LoRa/WiFi)
  playback, games and QSO Bot are untouched and behave exactly as before.
- `MorseOutput.cpp`: no behavior change to `printToScroll_internal()`
  itself — same wrap logic, same order, same conditions. The only change
  is that its `screenPos` counter moved from a function-local `static` to
  a translation-unit-scope `static` (`scrollScreenPos`), so a new
  read-only query `MorseOutput::wordNeedsWrap(uint16_t wordLen)` can read
  it. Both are `static` storage duration, so this is a visibility change
  only, not a lifetime change. `dispGeneratedChar()` and
  `printToScroll_internal()` both run synchronously in the main loop —
  no FreeRTOS task or ISR boundary is crossed — so this introduces no new
  race; flagging proactively given this file's history (#196).

## Why

Feedback from testing on a physical M32 Pocket (LCD): when copying CW and
writing it down in fixed-size groups (5-character groups, but the same
applies to single characters, 2/3-character groups, or free-form words),
a group would sometimes get split across the display's line wrap — one
or two characters stranded at the end of a line, the rest starting the
next. That makes comparing the display against handwritten copy harder
than it needs to be, since the on-screen "columns" no longer line up with
the actual groups.

This is only fixable for the CW Generator because it already holds the
complete upcoming word in `clearText` before revealing it
character-by-character (paced to the CW audio) — the fix just looks
ahead before the first character of a new word. Live keyed/decoded CW
doesn't have this property: the device genuinely can't know how long the
current "word" is until the operator pauses, so those paths are
intentionally left as they are.

## Open question

Should this always be on, or would you rather it be an opt-in preference
(e.g. "Word Wrap" under General settings, default **off** so existing
users see no change unless they choose it)?

Leaning towards "just fix it" — it only ever produces the same or better
line breaks than the old character-count wrap, no case where it looks
worse. But flagging the alternative since a toggle would need its own
manual entry (EN+DE) and an accessibility voice clip (§8), both of which
the always-on version avoids entirely. Happy to add the preference if
you'd rather users opt in explicitly.

## Test plan

- [x] Builds clean for `heltec_wifi_lora_32_V2` (Classic M32) and
      `pocketwroom` (M32 Pocket)
- [x] Flashed to a physical M32 Pocket; CW Generator tested across
      Callsigns, Mixed, Practice Set, Random, CW Abbrevs, and English
      Words — groups/words of varying length never split across a line
      break
- [x] Koch Trainer → CW Generator tested the same way, including lessons
      where word length varies within one session — wraps correctly
      every time
- [x] Confirmed Echo Trainer / CW Keyer / decoded-audio display is
      visually unchanged (still wraps by character count, as before)

## Scope

No new preference, NVS key, menu entry, or protocol command — nothing to
update in the manuals, Protocol Description, or `prefPos`/`extraItems`/
snapshot bookkeeping, unless the preference above is wanted, in which
case all of that would apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)