### PR TITLE
CW Generator: highlight vvv<ka> opener and + closer in bold

### DIFF
--- a/Documentation/User Manual/Version 9.x/manual_de.md
+++ b/Documentation/User Manual/Version 9.x/manual_de.md
@@ -653,7 +653,11 @@ du auch diese zum Starten und Stoppen verwenden).
 Beim Start wird zunächst *vvv\<ka>*
 (**\...\_  \...\_  \...\_  \_.\_.\_**) im Morsecode als Warnsignal
 ausgegeben, bevor die eigentliche Generierung von Gruppen oder Wörtern
-beginnt.
+beginnt. Auf dem Display wird dieses einleitende *vvv\<ka>* — und, falls
+**Max \# of Words** gesetzt ist, das abschließende "+", das das Ende der
+Sequenz markiert (siehe **6.2.4 Einstellungen zur CW-Generierung**) —
+**fett** dargestellt, damit du sofort erkennst, wo eine
+Sequenz beginnt und endet.
 
 Durch Aktivieren der Einstellung **Stop/Next/Rep** spielt der Morserino
 jeweils nur ein Wort oder eine Zeichengruppe ab und wartet dann auf eine
@@ -3279,7 +3283,7 @@ Trainer relevant!
 | **Call Prefixes** | Über diese Einstellung kannst du sehr seltene Präfixe herausfiltern und nur Rufzeichen mit geläufigeren Präfixen erhalten. | **Common only** / All |
 | **Length Abbrev** | Wähle die maximale Länge der zufällig generierten gängigen CW-Abkürzungen und Q-Gruppen. | **Unlimited** / max. 2 – max. 6 |
 | **Length Words** | Wähle die maximale Länge der zufällig generierten gängigen englischen Wörter. | **Unlimited** / max. 2 – max. 6 |
-| **Max \# of Words** | Wenn die angegebene Anzahl von Wörtern oder Buchstabengruppen generiert wurde, erzeugt der Morserino-32 ein abschließendes AR-Betriebszeichen ("+"), um das Ende dieser Sequenz anzuzeigen, und hält dann an und wartet. Mit einem Paddle-Berühren (oder einem Klick auf den ENCODER-Knopf) fährt er fort und erzeugt die nächste Wortfolge. *(Wenn „Auto Stop" aktiv ist, wird diese Einstellung im Modus CW Generator ignoriert.)* | **Unlimited** / 5 bis 250 in 5er-Schritten |
+| **Max \# of Words** | Wenn die angegebene Anzahl von Wörtern oder Buchstabengruppen generiert wurde, erzeugt der Morserino-32 ein abschließendes AR-Betriebszeichen ("+"), um das Ende dieser Sequenz anzuzeigen, und hält dann an und wartet. Mit einem Paddle-Berühren (oder einem Klick auf den ENCODER-Knopf) fährt er fort und erzeugt die nächste Wortfolge. Dieses abschließende "+" wird, wie das einleitende *vvv\<ka>*, fett auf dem Display dargestellt. *(Wenn „Auto Stop" aktiv ist, wird diese Einstellung im Modus CW Generator ignoriert.)* | **Unlimited** / 5 bis 250 in 5er-Schritten |
 | **Stop/Next/Rep** | Stoppt die Generierung von Morsezeichen nach jedem Wort in den Modi CW Generator und Koch Generator, um das Erlernen des Kopierens ohne Mitschreiben zu unterstützen. Fortfahren durch Berühren des rechten Paddles (nächstes Wort) oder des linken Paddles (Wort wiederholen). *Diese Option und die Option „Each Word 2x" sind nicht miteinander kompatibel: Wenn eine auf ON gesetzt wird, wird die andere automatisch auf OFF gesetzt.* | ON / **OFF** |
 | **CW Gen Displ** | Wähle, wie der CW-Generator oder die CW-Transceiver das Generierte oder Empfangene anzeigen sollen. | Display off / **Char by Char** / Word by word |
 | **Randomize File** | Wenn auf „On" gesetzt, überspringt der File Player nach jedem gesendeten Wort n Wörter (n = Zufallszahl zwischen 0 und 255). | **Off** / On |

--- a/Documentation/User Manual/Version 9.x/manual_en.md
+++ b/Documentation/User Manual/Version 9.x/manual_en.md
@@ -626,7 +626,11 @@ stop the session).
 
 When it starts, it will first alert you by generating *vvv\<ka>*
 (**\...\_  \...\_  \...\_  \_.\_.\_**) in Morse code, before it actually
-begins generating groups or words.
+begins generating groups or words. On the display, this opening
+*vvv\<ka>* — and, if **Max \# of Words** is set, the closing "+" that
+marks the end of the sequence (see **6.2.4 Preferences regarding CW
+Generation**) — are shown in **bold**, so you can immediately see where
+a sequence begins and ends.
 
 Enabling the preference **Stop/Next/Rep** will cause the Morserino
 to play only one word or group of characters, after which it will stop
@@ -2847,7 +2851,7 @@ Echo Trainer!
 | Call Prefixes | You can use this setting to filter out very rare prefixes, and get only call signs with more common prefixes. | **Common only** / All |
 | Length Abbrev | Select the maximum length of the randomly generated common CW abbreviations and Q groups | **Unlimited** / max. 2 – max. 6 |
 | Length Words | Select the maximum length of the randomly generated common English words | **Unlimited** / max. 2 – max. 6 |
-| Max \# of Words | When the specified number of words or letter groups has been generated, the Morserino-32 will generate a final AR ("+") pro sign to indicate that this sequence is over, and then pause and wait – with a touch of a paddle (or clicking the ENCODER knob) it will continue and generate the next sequence of words. *(When "Auto Stop" is active, this preference will be ignored in CW Generator mode.)*    |                                                                                                                                                                                        **Unlimited** / 5 to 250 in steps of 5 |
+| Max \# of Words | When the specified number of words or letter groups has been generated, the Morserino-32 will generate a final AR ("+") pro sign to indicate that this sequence is over, and then pause and wait – with a touch of a paddle (or clicking the ENCODER knob) it will continue and generate the next sequence of words. This closing "+", like the opening *vvv\<ka>*, is shown in bold on the display. *(When "Auto Stop" is active, this preference will be ignored in CW Generator mode.)*    |                                                                                                                                                                                        **Unlimited** / 5 to 250 in steps of 5 |
 | Stop/Next/Rep | Stops the generating of morse characters after each word in CW Generator and Koch Generator modes to help with learning head copying. Continue by touching the right paddle to play the next word, or by touching the left paddle to repeat the word. *This option and the option 'Each Word 2x' are not compatible with each other, setting one to ON, will set the other to OFF automatically.* | ON / **OFF** |
 | CW Gen Displ | Select, how the CW Generator or the CW Transceivers should display what is generated or received | Display off / **Char by Char** / Word by word |
 | Randomize File | If set to „On", file player will skip n words after each word sent (n = random number between 0 and 255) | **Off** / On |

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -289,6 +289,13 @@ boolean genIsActive= false;                       // flag for trainer mode
 boolean startFirst = true;                        // to indicate that we are starting a new sequence in the trainer modi
 boolean firstTime = true;                         /// for word doubler mode
 
+/// set by fetchNewWord() while clearText holds the fixed "vvv<ka>" pass-opener or
+/// the "+" pass-closer, read by dispGeneratedChar()/generateCW() for as long as
+/// clearText still holds characters from that word (unlike newWordForDisplay below,
+/// this is not a one-shot flag: it must stay true across all of that word's
+/// characters, not just the first)
+boolean frameWordForDisplay = false;
+
 uint8_t wordCounter = 0;                          // for maxSequence
 uint16_t errCounter = 0;                          // counting errors in echo trainer mode
 boolean stopFlag = false;                         // for maxSequence
@@ -2078,7 +2085,9 @@ void generateCW () {          ////// this is called from loop() (frequently!)  a
                 if (MorsePreferences::pliste[posGeneratorDisplay].value == DISPLAY_BY_WORD &&
                     (morseState == loraTrx || morseState == wifiTrx || morseState == morseGenerator || playCW == true))
                   {
-                      displayGeneratedMorse(morseState == morseGenerator ? REGULAR : BOLD, cleanUpProSigns(clearText));
+                      displayGeneratedMorse(
+                          (morseState == morseGenerator && !frameWordForDisplay) ? REGULAR : BOLD,
+                          cleanUpProSigns(clearText));
                       //clearText = "";
                   }
                 }
@@ -2281,7 +2290,8 @@ void dispGeneratedChar() {
         // cleanUpProSigns takes String& — construct one from our char buffer
         String charString(charBuf);
         displayGeneratedMorse(
-            (morseState == loraTrx || morseState == wifiTrx || generatorMode == KOCH_LEARN)
+            ((frameWordForDisplay && morseState == morseGenerator) ||
+             morseState == loraTrx || morseState == wifiTrx || generatorMode == KOCH_LEARN)
                 ? BOLD : REGULAR,
             cleanUpProSigns(charString));
         if (generatorMode == KOCH_LEARN) {
@@ -2303,6 +2313,8 @@ void dispGeneratedChar() {
 void fetchNewWord() {
   int rssi, rxWpm, rv;
   char numBuffer[16];                // for number to string conversion with sprintf()
+
+  frameWordForDisplay = false;       // only the "vvv<ka>" opener and "+" closer below turn this back on
 
 
     if (morseState == loraTrx || morseState == wifiTrx) {                     // we check the rxBuffer and see if we received something
@@ -2363,6 +2375,7 @@ void fetchNewWord() {
     }
     if (startFirst == true)  {                                 /// do the intial sequence in trainer mode, too
         clearText = "vvvA";
+        frameWordForDisplay = true;
         startFirst = false;
     } else if (morseState == morseGenerator && MorsePreferences::pliste[posWordDoubler].value != 0 && firstTime == false) {
         clearText = echoTrainerWord;
@@ -2403,6 +2416,7 @@ void fetchNewWord() {
                                 int limit = 1 + MorsePreferences::pliste[posMaxSequence].value;
                                 if (wordCounter == limit) {
                                   clearText = "+";
+                                  frameWordForDisplay = true;
                                   echoStop = true;
                                   if (echoTrainerState == REPEAT_WORD)
                                     echoTrainerState = SEND_WORD;


### PR DESCRIPTION
## Summary
- Highlights the fixed "vvv<ka>" pass-opener and the optional "+" pass-closer
  (Max # of Words) in bold, so it's immediately visible where a CW Generator
  sequence begins and ends.
- Uses the existing BOLD font attribute (same weight already used for
  received/decoded CW), so no new display style and no per-theme risk.
- Updated EN + DE user manuals to describe the markers as bold.

## Test plan
- [x] Builds cleanly for pocketwroom and heltec_wifi_lora_32_V2
- [x] Flashed to M32 Pocket and visually confirmed the vvv<ka> opener and
      the "+" closer (with Max # of Words set) render in bold