### PR TITLE
Koch Lesson menu: show total lesson count alongside the current one

### DIFF
--- a/Documentation/User Manual/Version 8.x/manual_de.md
+++ b/Documentation/User Manual/Version 8.x/manual_de.md
@@ -1000,8 +1000,9 @@ einzustellen.
 ### Koch: Select Lesson
 
 Wähle eine „Koch-Lektion" zwischen 1 und 51 (insgesamt 51 Zeichen
-werden nach der Koch-Methode gelernt). Lektion und zugehöriges Zeichen
-werden im Menü angezeigt.
+werden nach der Koch-Methode gelernt). Im Menü werden die Lektionsnummer,
+die Gesamtzahl der Lektionen der aktuell gewählten Koch-Sequenz (z. B.
+`21/39:`) und das zugehörige Zeichen angezeigt.
 
 Die Zeichenreihenfolge wurde von Koch nicht streng festgelegt, daher
 verwenden verschiedene Lernkurse leicht unterschiedliche Reihenfolgen.

--- a/Documentation/User Manual/Version 8.x/manual_en.md
+++ b/Documentation/User Manual/Version 8.x/manual_en.md
@@ -988,8 +988,9 @@ perfectly fits your needs.
 ### Koch: Select Lesson
 
 Select a "Koch lesson" between 1 and 51 (you will learn 51 characters
-in total through the Koch method). The number of the lesson and the
-character associated with that lesson will be displayed in the menu.
+in total through the Koch method). The menu displays the lesson number,
+the total number of lessons in the currently selected Koch sequence
+(e.g. `21/39:`), and the character associated with that lesson.
 
 The order of the characters learned has not been strictly defined by
 Koch, and therefore different learning courses use slightly different

--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -1070,7 +1070,11 @@ String MorsePreferences::getValueLine(prefPos pos) {
     case posKochFilter:
       str = koch.getNewChar();
       cleanUpProSigns(str);
-      sprintf(numBuffer, "%2i char %s", MorsePreferences::kochFilter, str.c_str());
+      // "N/M: x": lesson N of M total (kochMaximum tracks the active sequence's
+      // lesson count, incl. the LICW carousel window), then the new character.
+      // Kept slash-compact - a worst-case prosign char (e.g. "<err>") plus
+      // "N/M char " would overflow the 14-char OLED value-line budget.
+      sprintf(numBuffer, "%2i/%d: %s", MorsePreferences::kochFilter, MorsePreferences::kochMaximum, str.c_str());
       str = String(numBuffer);
       break;
     case posLoraBand:


### PR DESCRIPTION
## Summary
- Koch Trainer → Select Lesson now shows `N/M: x` (lesson N of the sequence's M total, then the newest character) instead of just `N char x`, so the total is visible without leaving the menu.
- `kochMaximum` already tracks the correct total for every sequence (native/LCWO/CW Academy/LICW carousel window/Custom Chars/adaptive), so no new state was added.
- Kept the format slash-compact (`N/M: x`) to stay inside the 14-char OLED value-line budget even for a worst-case prosign character like `<err>`.
- Updated the EN + DE user manuals (Version 8.x) to mention the new display format.

## Test plan
- [x] Builds cleanly for `heltec_wifi_lora_32_V2` (Classic, OLED)
- [x] Builds cleanly for `pocketwroom` (Pocket, LCD)
- [x] Flashed to a connected M32 Pocket and confirmed the menu shows e.g. `21/39: y`
- [x] Re-ran `extract_voice_strings.py` — empty diff, no accessibility voice clip owed (the Koch Lesson value line was already exempt as dynamic content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)