### PR TITLE
Add Echo Think Time preference for head copy practice

### DIFF
--- a/Documentation/User Manual/Version 8.x/manual_en.md
+++ b/Documentation/User Manual/Version 8.x/manual_en.md
@@ -943,6 +943,12 @@ adaptive speed, the speed for keying your input stays at that maximum
 (so you can train your copying at faster speeds than you are comfortable
 to use when keying).
 
+**Echo Think Time:** Set this to the number of seconds you would like
+to wait after the prompt has been sent before the Echo Trainer expects
+your response. This is useful for head copy practice, especially with
+call signs, where you may need a moment to build a mental picture of
+what you heard before keying your answer. Default is 0 (no extra wait).
+
 **Intercharacter Space** and **Interword Space**: The first preference
 defines the pause between characters in the prompt the M32 is generating
 (the same as in the Generator modes, see there); both preferences also
@@ -2705,6 +2711,7 @@ time" after the prompt before you must begin keying your response!
 | Tone Shift | The pitch of the tone, when you are using the Echo Trainer mode or transmitting in a transceiver mode, can either be the same as the one you get from the receiver (or from the prompt in Echo Trainer mode), or can be a half tone lower or a half tone higher. | **No Tone Shift** / Up 1/2 Tone / Down 1/2 Tone |
 | Adaptv. Speed | If this is set to ON, the speed will be increased by 1 WpM whenever you gave a correct response in Echo Trainer mode, and will be decreased by 1 whenever you made a mistake. | ON / **OFF** |
 | Echo Speed Max | Set this to the maximum speed you would like to use for keying in Echo Trainer mode. If you set the speed faster than this value with the Encoder, or if it is getting faster as a result of adaptive speed, the speed for keying your input stays at that maximum. | **No limit** / 5 – 50 wpm (in steps of 5 wpm) |
+| Echo Think Time | Sets the number of seconds added after the prompt before the Echo Trainer expects your response. Useful for head copy practice with call signs, where you need thinking time without changing the keying speed. | **0s** / 1s – 10s / 15s / 20s |
 
 
 

--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -71,6 +71,7 @@ const char * prefName[] = {
                       "randomLength", "callLength", "callContinent", "callCommon","abbrevLength", "wordLength",
                       "GeneratorDispl", "wordDoubler", "echoDisplay", "echoRepeats", "echoConf",
                       "KeyExternalTx", "LoraCwTransmit", "goertzelBW", "speedAdapt", "echoSpeedMax",
+                      "echoThinkTime",
                       "KochSeq", "carouselStart", "latency", "randomFile", "extAudioOnDecod", "timeOut",
                       "quickStart", "outputCase", "autoStop", "maxSequence", "LoraChannel",
 #ifdef CONFIG_BLUETOOTH_KEYBOARD
@@ -313,6 +314,13 @@ parameter MorsePreferences::pliste[] = {
     "Maximum response speed in echo trainer (0=no limit)",
     true,
     {"No limit", "5 wpm", "10 wpm", "15 wpm", "20 wpm", "25 wpm", "30 wpm", "35 wpm", "40 wpm", "45 wpm", "50 wpm"}
+  },
+  {
+    0, 0, 12, 1,                                                // Echo trainer: thinking time in seconds (0 = no extra wait)
+    "Echo Think Time",
+    "Seconds to wait before echo trainer expects your response",
+    true,
+    {"0s", "1s", "2s", "3s", "4s", "5s", "6s", "7s", "8s", "9s", "10s", "15s", "20s"}
   },
   {
     0, 0, 4, 1,                                                 // select Koch sequence: 0 = native/JLMC, 1 = LCWO, 2 = CW Academy, 3 = LICW, 4 = Custom
@@ -605,14 +613,14 @@ FilePart MorsePreferences::fileParts[MAX_FILE_PARTS];
  prefPos MorsePreferences::echoPlayerOptions[] = { PREFPOS_COMMON_CORE LINEOUT THEME BLUE posSerialOut, posPolarity, posExtPddlPolarity,
 
                                                    posCurtisMode, posCurtisBDahTiming, posCurtisBDotTiming, posACS,  posLatency, posInterCharSpace, posInterWordSpace,
-                                                   posMaxSequence, posRandomFile, posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax,
+                                                   posMaxSequence, posRandomFile, posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax, posEchoThinkTime,
                                                  };
 
  prefPos MorsePreferences::echoTrainerOptions[]= { PREFPOS_COMMON_CORE LINEOUT THEME BLUE posSerialOut, posPolarity, posExtPddlPolarity,
 
                                                    posCurtisMode, posCurtisBDahTiming, posCurtisBDotTiming, posACS,  posLatency, posInterCharSpace, posInterWordSpace,
                                                    posRandomOption, posRandomLength, posCallLength, posCallContinent, posCallCommon, posAbbrevLength,  posWordLength,
-                                                   posMaxSequence, posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax,
+                                                   posMaxSequence, posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax, posEchoThinkTime,
                                                  };
 
  prefPos MorsePreferences::kochGenOptions[] =    { PREFPOS_COMMON_CORE LINEOUT THEME BLUE posSerialOut, posPolarity, posExtPddlPolarity,
@@ -626,7 +634,7 @@ FilePart MorsePreferences::fileParts[MAX_FILE_PARTS];
 
                                                    posCurtisMode, posCurtisBDahTiming, posCurtisBDotTiming, posACS,  posLatency, posKochSeq, posCarouselStart,
                                                    posInterCharSpace, posInterWordSpace, posRandomLength, posAbbrevLength,  posWordLength,
-                                                   posMaxSequence, posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax,
+                                                   posMaxSequence, posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax, posEchoThinkTime,
                                                  };
 
  prefPos MorsePreferences::loraTrxOptions[] =    { PREFPOS_COMMON_CORE  LINEOUT THEME BLUE posSerialOut, posPolarity, posExtPddlPolarity,
@@ -674,7 +682,7 @@ FilePart MorsePreferences::fileParts[MAX_FILE_PARTS];
                                                    posKochSeq, posCarouselStart,
                                                    posInterCharSpace, posInterWordSpace, posRandomOption, posRandomLength, posCallLength, posCallContinent, posCallCommon, posAbbrevLength,  posWordLength,
                                                    posMaxSequence, posAutoStop, posGeneratorDisplay, posRandomFile, posWordDoubler,
-                                                   posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax,
+                                                   posEchoRepeats, posEchoDisplay, posEchoConf, posEchoToneShift, posSpeedAdapt, posEchoSpeedMax, posEchoThinkTime,
                                                    posKeyExternalTx, posLoraCwTransmit,
                                                    posLoraChannel,
                                                    posGoertzelBandwidth, posExtAudioOnDecode,

--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -2107,7 +2107,7 @@ void generateCW () {          ////// this is called from loop() (frequently!)  a
                                                     displayGeneratedMorse(INVERSE_REGULAR, ">");
                                                 }
                                                 ++repeats;
-                                                genTimer = millis() + 1400 + interCharacterSpace + interWordSpace / 3;
+                                                genTimer = millis() + 1400 + interCharacterSpace + interWordSpace / 3 + (MorsePreferences::pliste[posEchoThinkTime].value * 1000UL);
  
                                                 // Apply response speed limit
                                                 uint8_t speedMaxIdx = MorsePreferences::pliste[posEchoSpeedMax].value;

--- a/Software/src/Version 6 and newer/morsedefs.h
+++ b/Software/src/Version 6 and newer/morsedefs.h
@@ -401,7 +401,7 @@ enum prefPos : uint8_t {
                 posEchoToneShift, posInterWordSpace, posInterCharSpace, posRandomOption,                      // 8
                 posRandomLength, posCallLength, posCallContinent, posCallCommon, posAbbrevLength, posWordLength,                               // 12
                 posGeneratorDisplay, posWordDoubler, posEchoDisplay, posEchoRepeats,  posEchoConf,            // 16
-                posKeyExternalTx, posLoraCwTransmit, posGoertzelBandwidth, posSpeedAdapt, posEchoSpeedMax,                    // 21
+                posKeyExternalTx, posLoraCwTransmit, posGoertzelBandwidth, posSpeedAdapt, posEchoSpeedMax, posEchoThinkTime,  // 21
                 posKochSeq, posCarouselStart, posLatency, posRandomFile, posExtAudioOnDecode, posTimeOut,     // 25
                 posQuickStart, posOutputCase, posAutoStop, posMaxSequence, posLoraChannel,                    // 31
 #ifdef CONFIG_BLUETOOTH_KEYBOARD


### PR DESCRIPTION
Adds a new 'Echo Think Time' preference to the Echo Trainer, allowing operators to set a fixed number of seconds (0-20s) added after the prompt before the trainer expects a response.

This is particularly useful for head copy practice with call signs, where the operator needs thinking time to mentally reconstruct what they heard without having to reduce the prompt speed or change the dot/dash ratio — which affects the whole device globally, not just the Echo Trainer.

The existing workaround suggested by users (adjusting dot/dash ratio or inter-word space) changes global device behaviour. This change is completely isolated to the Echo Trainer state machine.

Changes:
- morsedefs.h: added posEchoThinkTime to preference enum
- MorsePreferences.cpp: added preference entry (0-20s) and included in all echo trainer option lists; added echoThinkTime to prefName array
- m32_v6.ino: applied think time to genTimer calculation in echo trainer state machine
- manual_en.md: documented new preference in prose section and reference table