### PR TITLE
Fix TLV320AIC3100 sidetone clipping on M32 Pocket (harsh tone, independent of Tone Volume)

### DIFF
--- a/Software/src/Version 6 and newer/MorseOutput.cpp
+++ b/Software/src/Version 6 and newer/MorseOutput.cpp
@@ -1984,7 +1984,7 @@ float calcVolume(uint8_t v) { // v = 0 - 19
 void soundEnableHeadphone(void) {
     codec.enableHeadphoneAmp();
     // codec.setHeadphoneVolume(-30.0f,-30.0f); // volume regulated by encoder
-    codec.setHeadphoneVolume(calcVolume(MorsePreferences::sidetoneVolume)-12.0,calcVolume(MorsePreferences::sidetoneVolume)-12.0);
+    codec.setHeadphoneVolume(calcVolume(MorsePreferences::sidetoneVolume)-3.0,calcVolume(MorsePreferences::sidetoneVolume)-3.0);
     codec.setHeadphoneGain(9.0f,9.0f); // valid db: 0 - 9 (max); was 0dB, raised after the setDACVolume fix below left headroom unused
     codec.setHeadphoneMute(false); // unmute hp
     codec.setSpeakerMute(true); // mute class d speaker amp
@@ -1992,7 +1992,7 @@ void soundEnableHeadphone(void) {
 
 void soundEnableSpeaker(void) {
     codec.enableSpeakerAmp();
-    codec.setSpeakerGain(18.0f); // valid db: 6, 12, 18, 24; was 6dB (the minimum step)
+    codec.setSpeakerGain(12.0f); // valid db: 6, 12, 18, 24; 18 was still too loud at full Tone Volume
     // codec.setSpeakerVolume(-13.0f); // volume set by encoder
     codec.setSpeakerVolume(calcVolume(MorsePreferences::sidetoneVolume));
     codec.setSpeakerMute(false); // unmute class d speaker amp
@@ -2012,7 +2012,7 @@ void soundEnableLineOut(bool muted = false, bool variable = false) {
       codec.setHeadphoneVolume(0.0, 0.0); // volume 0db on line-out
     }
     else
-      codec.setHeadphoneVolume(calcVolume(MorsePreferences::sidetoneVolume)-12.0,calcVolume(MorsePreferences::sidetoneVolume)-12.0);
+      codec.setHeadphoneVolume(calcVolume(MorsePreferences::sidetoneVolume)-3.0,calcVolume(MorsePreferences::sidetoneVolume)-3.0);
 
     if (muted)
           codec.setSpeakerMute(true); // mute class d speaker amp
@@ -2020,7 +2020,7 @@ void soundEnableLineOut(bool muted = false, bool variable = false) {
       {
         //DEBUG ("Not muted!");
         codec.enableSpeakerAmp();
-        codec.setSpeakerGain(18.0f); // valid db: 6, 12, 18, 24; was 6dB (the minimum step)
+        codec.setSpeakerGain(12.0f); // valid db: 6, 12, 18, 24; 18 was still too loud at full Tone Volume
         // codec.setSpeakerVolume(-10.0f); // volume set by encoder
         codec.setSpeakerVolume(calcVolume(MorsePreferences::sidetoneVolume));
         codec.setSpeakerMute(false); // unmute class d speaker amp
@@ -2037,7 +2037,7 @@ void MorseOutput::soundSetVolume(uint8_t v) { // v = 0 - 19
             codec.setHeadphoneMute(true); // mute hp
         else  
             codec.setHeadphoneMute(false);
-        codec.setHeadphoneVolume(calcVolume(v)-12.0, calcVolume(v)-12.0); // reduce headphone volume by 6dB to match speaker volume
+        codec.setHeadphoneVolume(calcVolume(v)-3.0, calcVolume(v)-3.0); // small offset -- 0dB was a touch too loud, -6dB was too quiet
         break;
       case 1: // line-out, speaker not muted, fixed l-o gain
         if (v==0)
@@ -2057,7 +2057,7 @@ void MorseOutput::soundSetVolume(uint8_t v) { // v = 0 - 19
             codec.setHeadphoneMute(false);
         }
         codec.setSpeakerVolume(calcVolume(v));
-        codec.setHeadphoneVolume(calcVolume(v)-12.0, calcVolume(v)-12.0); // reduce headphone volume by 6dB to match speaker volume
+        codec.setHeadphoneVolume(calcVolume(v)-3.0, calcVolume(v)-3.0); // small offset -- 0dB was a touch too loud, -6dB was too quiet
         break;
       case 3: // line-out, speaker muted, fixed l-o gain
         break;
@@ -2068,7 +2068,7 @@ void MorseOutput::soundSetVolume(uint8_t v) { // v = 0 - 19
       codec.setHeadphoneMute(true); // mute hp
     else  
       codec.setHeadphoneMute(false);
-    codec.setHeadphoneVolume(calcVolume(v)-12.0, calcVolume(v)-12.0); // reduce headphone volume by 6dB to match speaker volume
+    codec.setHeadphoneVolume(calcVolume(v)-3.0, calcVolume(v)-3.0); // small offset -- 0dB was a touch too loud, -6dB was too quiet
   } */ 
   else {
     if (v==0)
@@ -2275,7 +2275,9 @@ void MorseOutput::soundSetup()
       // driven by the Tone Volume preference). +20 dB of digital gain here was
       // clipping every tone internally, before it ever reached that analog stage
       // -- audible as a harsh, harmonic-heavy tone regardless of Tone Volume.
-      codec.setDACVolume(0.0f,0.0f);
+      // +2 dB: the last bit of headroom before the 0.7-scaled sidetone would
+      // start clipping again (20*log10(1/0.7) ~= 3.1 dB ceiling).
+      codec.setDACVolume(2.0f,2.0f);
       codec.enableADC();
       codec.setADCGain(-12.0f);
       // Enable the speaker and then run soundEventHandler once to mute/unmute HP/Spk depending on HS plug state

--- a/Software/src/Version 6 and newer/MorseOutput.cpp
+++ b/Software/src/Version 6 and newer/MorseOutput.cpp
@@ -1985,14 +1985,14 @@ void soundEnableHeadphone(void) {
     codec.enableHeadphoneAmp();
     // codec.setHeadphoneVolume(-30.0f,-30.0f); // volume regulated by encoder
     codec.setHeadphoneVolume(calcVolume(MorsePreferences::sidetoneVolume)-12.0,calcVolume(MorsePreferences::sidetoneVolume)-12.0);
-    codec.setHeadphoneGain(0.0f,0.0f); // valid db: 0 - 9
+    codec.setHeadphoneGain(9.0f,9.0f); // valid db: 0 - 9 (max); was 0dB, raised after the setDACVolume fix below left headroom unused
     codec.setHeadphoneMute(false); // unmute hp
     codec.setSpeakerMute(true); // mute class d speaker amp
 }
 
 void soundEnableSpeaker(void) {
     codec.enableSpeakerAmp();
-    codec.setSpeakerGain(6.0f); // valid db: 6, 12, 18, 24
+    codec.setSpeakerGain(18.0f); // valid db: 6, 12, 18, 24; was 6dB (the minimum step)
     // codec.setSpeakerVolume(-13.0f); // volume set by encoder
     codec.setSpeakerVolume(calcVolume(MorsePreferences::sidetoneVolume));
     codec.setSpeakerMute(false); // unmute class d speaker amp
@@ -2020,7 +2020,7 @@ void soundEnableLineOut(bool muted = false, bool variable = false) {
       {
         //DEBUG ("Not muted!");
         codec.enableSpeakerAmp();
-        codec.setSpeakerGain(6.0f); // valid db: 6, 12, 18, 24
+        codec.setSpeakerGain(18.0f); // valid db: 6, 12, 18, 24; was 6dB (the minimum step)
         // codec.setSpeakerVolume(-10.0f); // volume set by encoder
         codec.setSpeakerVolume(calcVolume(MorsePreferences::sidetoneVolume));
         codec.setSpeakerMute(false); // unmute class d speaker amp
@@ -2269,7 +2269,13 @@ void MorseOutput::soundSetup()
       // codec.writeRegister(AIC31XX_MICBIAS,11);
       codec.enableDAC();
       codec.setDACMute(false);
-      codec.setDACVolume(20.0f,20.0f);
+      // Unity gain: the sidetone already arrives close to full scale (see
+      // sidetone.setVolume(0.7) below), and actual loudness is set downstream
+      // by the analog headphone/speaker stage (setHeadphoneVolume/setSpeakerVolume,
+      // driven by the Tone Volume preference). +20 dB of digital gain here was
+      // clipping every tone internally, before it ever reached that analog stage
+      // -- audible as a harsh, harmonic-heavy tone regardless of Tone Volume.
+      codec.setDACVolume(0.0f,0.0f);
       codec.enableADC();
       codec.setADCGain(-12.0f);
       // Enable the speaker and then run soundEventHandler once to mute/unmute HP/Spk depending on HS plug state


### PR DESCRIPTION
While comparing the Pocket's sidetone to LCWO's tone generator, I found that CW sidetone on `pocketwroom`-family boards (TLV320AIC3100 codec) has been clipping hard inside the codec on every tone, regardless of the Tone Volume setting.

**Root cause**

`soundSetup()` set the codec's digital DAC volume to `+20 dB` (`codec.setDACVolume(20.0f, 20.0f)`), close to the chip's `+24 dB` ceiling. The I2S sidetone already arrives at 70% of full scale (`sidetone.setVolume(0.7)` in the vendored `cw-i2s-sidetone` library), so +20 dB (10x linear gain) pushed it to roughly 7x full scale — the codec saturated hard, long before the signal reached the analog headphone/speaker stage that Tone Volume actually controls. Lowering Tone Volume couldn't fix this, since the clipping happened upstream of that control.

Confirmed on real hardware: a line-out recording at moderate Tone Volume measured the 3rd harmonic only **1.9 dB below the fundamental** (an ideal square wave tops out at -9.5 dB there) — consistent with hard digital clipping, not the clean sine + Blackman-Harris envelope the I2S path is designed to produce. After the fix, the same measurement showed all harmonics 70+ dB down, and a peak/RMS crest factor matching a clean sine.

`git blame` traces the `+20 dB` value back to the original V7.0 hardware bring-up commit, with no comment explaining it.

**Fix (2 commits)**

1. `setDACVolume` → 2 dB (was 20 dB) — just inside the ~3 dB of headroom the 0.7-scaled sidetone has before it clips again. No more internal clipping.
2. Rebalanced the analog gain stages, which turned out to have never been tuned (speaker gain at its lowest step, headphone gain at 0 of its range) and to have a ~21 dB gap between the speaker and headphone/line-out paths at the same Tone Volume setting — partly by design (headphones sit at the ear and need far less gain than a speaker filling a room) but the actual numbers hadn't been chosen deliberately:
   - speaker gain: 12 dB (of the four valid steps: 6/12/18/24) — tried 24 and 18 first, both too loud at full Tone Volume
   - headphone gain: 9 dB (max of the 0-9 dB range)
   - headphone volume offset: -3 dB (an existing fixed offset was -12 dB, inconsistent with its own comment claiming -6 dB; removing it entirely was a touch too loud, -6 dB brought back audible noise floor from having to turn Tone Volume up further to compensate)

All four values were landed on by ear on a real M32 Pocket, comparing speaker and headphone output at matching Tone Volume settings.

**Scope**

Only affects `CONFIG_TLV320AIC3100` builds (`pocketwroom`, `pocketwroom-lora`, `pocketwroom-170x240`, `pocketwroom-accessibility`, `heltec-vision-master-t190`). The classic M32's PWM sidetone path (`heltec_wifi_lora_32_V2`) is untouched — it doesn't compile this code at all. Didn't touch the WM8960-based boards (`heltec_wifi_kit_32_V3`, `heltec_wifi_lora_32_V3`); their gain staging is separate code I haven't audited.

**Testing**

- `pocketwroom` and `heltec_wifi_lora_32_V2` both build clean.
- Flashed to a real M32 Pocket through several iterations; confirmed by ear at each step. Final result: clean, comfortable, comparable loudness on both speaker and headphone/line-out, no clipping or audible noise floor.

**Question for @oe1wkl**

Before this fix, the Pocket's sidetone was, by coincidence or not, fairly close in character to the classic M32's hardware-PWM square wave (both dominated by strong odd harmonics). If that similarity was ever intentional, let me know and I'm happy to add a menu-selectable "tone character" option instead of just removing it outright. Absent that, I'm treating this as an unintended gain-staging bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)