### PR TITLE
Fix Koch lesson filter being ignored for Custom Character Sets

### DIFF
--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -2020,8 +2020,7 @@ void MorsePreferences::writePreferences(const char* repository) {
 
      if (MorsePreferences::kochFilter != pref.getUChar("kochFilter")) {
         pref.putUChar("kochFilter", MorsePreferences::kochFilter);
-        if (!MorsePreferences::useCustomChars)                          // we update these only if we do not use a custom character set!
-          koch.setup();
+        koch.setup();
      }
 
      if (MorsePreferences::wlanSSID != pref.getString("wlanSSID")) {
@@ -2891,8 +2890,8 @@ void Koch::setup() {                                                // create th
   else
     setKochChars(MorsePreferences::pliste[posKochSeq].value);
   //// populate the array for abbreviations and words according to length and Koch filter
-  createWords(MorsePreferences::pliste[posWordLength].value, MorsePreferences::useCustomChars ? kochCharsLength+1 : MorsePreferences::kochFilter) ;  //
-  createAbbr(MorsePreferences::pliste[posAbbrevLength].value, MorsePreferences::useCustomChars ? kochCharsLength+1 : MorsePreferences::kochFilter);
+  createWords(MorsePreferences::pliste[posWordLength].value, MorsePreferences::kochFilter) ;  //
+  createAbbr(MorsePreferences::pliste[posAbbrevLength].value, MorsePreferences::kochFilter);
 
   String charSet = getCharSet();
   uint8_t probability = 0;


### PR DESCRIPTION
## Summary
- With a Custom Character Set active, `Koch::setup()` built the CW Abbrevs / English Words / Mixed word-index tables against the **entire** custom set instead of the current lesson (`kochFilter`), so those modes could serve words containing characters far beyond the learner's current lesson.
- `writePreferences()` also skipped `koch.setup()` on lesson change whenever a custom set was active, so Adaptive Random's probability table went stale on every lesson advance too.
- Both fixed to always use `kochFilter`, matching how the rest of the Custom Chars code (`setCustomChars()`, `getNewChar()`) already treats it as the lesson boundary.

Affects Koch Trainer's CW Generator and Echo Trainer (Words/Abbrevs/Mixed/Adaptive Random) when a Custom Character Set is configured. Random mode and the TFT games (which read the live character set directly rather than through the filtered index tables) were already correctly bounded and are unaffected. Built-in Koch sequences (non-custom) were also unaffected, since they already passed `kochFilter` correctly.

## Test plan
- [x] `pio run -e pocketwroom` — builds clean
- [x] `pio run -e heltec_wifi_lora_32_V2` — builds clean
- [x] Flashed to an M32 Pocket and confirmed English Words / CW Abbrevs under Koch Trainer now stay within the custom set's learned-lesson prefix