### PR TITLE
Fix: long-press to exit Preferences also exits the running mode

### DIFF
--- a/Software/src/Version 6 and newer/MorsePreferences.cpp
+++ b/Software/src/Version 6 and newer/MorsePreferences.cpp
@@ -860,7 +860,11 @@ boolean MorsePreferences::setupPreferences(uint8_t atMenu) {
                       break;
           case -1:    //////// long press indicates we are done with setting preferences - check if we need to store some of the preferences
 
-          exitFromHere: if (MorsePreferences::useCustomChars && MorsePreferences::customCharSet.length() == 0) {
+          exitFromHere: Buttons::modeButton.clicks = 0;   // swallow the long-press that ended preferences, so the
+                        // mode we return to doesn't read this same stale -1 as its own exit gesture
+                        // (ClickButton fires long-press while still held, then leaves `clicks` at -1
+                        // until the release resolves ~20-270ms later - see ClickButton.cpp:97-133)
+                        if (MorsePreferences::useCustomChars && MorsePreferences::customCharSet.length() == 0) {
                             // Bootstrap only: pull from the file player exclusively when no
                             // custom set is active yet (mirrors handleKochSequence()'s guard).
                             // Previously ran unconditionally on every preferences exit, which


### PR DESCRIPTION
## Summary
- Exiting the Preferences menu with a long press of the encoder button (double-click to enter, long-press to leave) was also kicking the user out of whatever mode they entered Preferences from (e.g. CW Generator) straight to the top menu, instead of returning them to that mode.
- Root cause: `ClickButton` fires a long click while the button is still held, and leaves its `clicks` member at `-1` for roughly 20-270ms afterward, until the release is debounced/resolved. `setupPreferences()`'s long-press exit branch never cleared this value before returning, so the calling mode's main loop read the same stale `-1` on its very next iteration and treated it as a fresh long-press on the mode itself - which is the universal "exit to top menu" gesture.
- Other sub-flows in `MorsePreferences.cpp` (`editPlayerIdentity`, `editPracticeChars`) already guard against exactly this by zeroing `Buttons::modeButton.clicks` after a long-press-terminated sub-flow returns; `setupPreferences()`'s own top-level exit path was missing the same guard.

## Fix
- `setupPreferences()` now swallows the long press at its `exitFromHere` exit point (`Buttons::modeButton.clicks = 0;`) before returning, matching the existing pattern elsewhere in the file.

## Test plan
- [x] Built `heltec_wifi_lora_32_V2` (Classic M32) - succeeds
- [x] Built and flashed `pocketwroom` (M32 Pocket) to a physical device
- [x] Manually verified on the M32 Pocket: enter CW Generator, double-click into Preferences, change a setting, long-press to exit - now correctly returns to the (paused) CW Generator instead of the top menu