### PR TITLE
Fix: long-press to exit a mode also skips menu levels

### DIFF
--- a/Software/src/Version 6 and newer/MorseMenu.cpp
+++ b/Software/src/Version 6 and newer/MorseMenu.cpp
@@ -289,6 +289,17 @@ static void a11yForgetMenuContext() { a11yMenuParent = a11yLastEntry = 0xFF; }
 
 
 void MorseMenu::menu_() {
+   // Swallow whatever button click got us here (typically the long-press that
+   // exits a running mode). ClickButton fires a long click while the button is
+   // still held and then leaves `clicks` frozen at -1 until the release
+   // resolves ~20-270ms later (see ClickButton.cpp:97-133). The setup work
+   // below (WiFi tear-down, volume write, ...) easily outlasts that window
+   // with no intervening Update() call, so without this the menu loop's own
+   // first read(s) of `clicks` see the same stale -1 and misread it as "go up
+   // one level" - repeatedly, once per loop iteration, until it decays. That
+   // walks newMenuPtr up several levels at once instead of landing on the
+   // mode we just left (mirrors the setupPreferences() exit fix above).
+   Buttons::modeButton.clicks = 0;
    // Memory-clearing reboot is now reactive (see MorseGameMode::allocate)
    // rather than preemptive on WiFi Trx exit. The heap stays fragmented
    // after WiFi Trx, but that only matters if the user immediately starts
@@ -422,6 +433,13 @@ void MorseMenu::menu_() {
         else {
             Buttons::modeButton.Update();
             command = Buttons::modeButton.clicks;
+            // Swallow immediately after capturing: menuDisplay() below can be slow enough
+            // (esp. on TFT) that the release happens before the loop's next Update() call
+            // gets to self-correct a lingering -1/1 (ClickButton.cpp:97-133), so a single
+            // long press could otherwise be re-read as -1 on the following iteration and
+            // walk newMenuPtr up an extra level (e.g. Koch Trainer::CW Generator::Random
+            // jumping straight to Koch Trainer instead of stopping one level up).
+            Buttons::modeButton.clicks = 0;
         }
 
 #ifdef CONFIG_AUDIO_A11Y


### PR DESCRIPTION
## Summary
Follow-up to #215. Same root cause (`ClickButton` fires a long click while the button is still held and leaves `clicks` frozen at `-1` for ~20-270ms after, until the release resolves - see `ClickButton.cpp:97-133`), but showing up in two more places, both in `menu_()`:

1. **Exiting a running mode landed several menu levels too high.** `menu_()`'s setup work (WiFi teardown, volume write, ...) easily outlasts the stale window with no intervening `Update()` call, so the menu loop's first read(s) of `clicks` saw the same stale `-1` left over from the mode's own long-press-exit and repeatedly hit "go up one level" before it decayed. Long-pressing out of CW Generator (or Echo Trainer, a Transceiver mode, etc.) could land you several levels above where you started instead of right back at it.
2. **A single long press inside the menu tree could skip a level.** After a legitimate long press moves `newMenuPtr` up one level, the loop's own `menuDisplay()` redraw can be slow enough (TFT especially) that the release lands before the next `Update()` call, so that call rereads the same stale `-1` and hops up yet another level. Example: long-pressing at `Koch Trainer::CW Generator::Random` landed at the top-level `Koch Trainer` heading instead of stopping one level up at `Koch Trainer::CW Generator`.

## Fix
Same swallow pattern already used elsewhere in this codebase (`editPlayerIdentity`, `editPracticeChars`, `MorseQsoBot.cpp`): clear `Buttons::modeButton.clicks` right where it's consumed - once at `menu_()`'s entry, and again immediately after each capture inside its own loop.

## Test plan
- [x] Built `heltec_wifi_lora_32_V2` (Classic M32) - succeeds
- [x] Built and flashed `pocketwroom` (M32 Pocket) to a physical device
- [x] Manually verified on the M32 Pocket: exiting CW Generator/Echo Trainer/Transceiver modes now returns to the exact mode/level left; long-pressing anywhere in the menu tree now moves exactly one level up

## Other findings not addressed here
While chasing this, I grepped every `Buttons::modeButton.clicks == -1` / `case -1` site across the games and QSO Bot to see how widespread this ClickButton-staleness class is. It's broader than what this PR (or #215) touches - I'm flagging it rather than fixing it myself, since these are self-contained subsystems you know better and I'd rather not reach into all of them at once:

- **Morse Invaders** (`MorseGame.cpp`): 4 unguarded `case -1` exit sites (e.g. lines 878, 939, 1044) that return control to the already-running `menu_()` loop without clearing `clicks` first - the same "leaks into the caller" failure mode as fix #1 above.
- **Radio Cave** (`MorseRadioCave.cpp`): 4 sites (e.g. lines 773, 2363, 2569), same pattern.
- **Morsel** (`MorseMorsel.cpp`): 8 sites - the most of any file, and notably some are *internal* state transitions (back to mode-select, back to role-pick), not just the final exit, so these could plausibly also hit the "double-fires within its own loop" failure mode (fix #2 above), not just the "leaks into the caller" one. I have not reproduced this on-device, only found it by inspection.
- **Fight the Pileup** (`MorsePileup.cpp`): already has one swallow (line 1829), but 5 further unguarded sites.
- **QSO Bot** (`MorseQsoBot.cpp`): already swallows in 4 places, but one more unguarded site (`userAborted`, line 937).

Happy to take a pass at these too if useful, but figured you'd want visibility first given how many spots are involved.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)