### PR TITLE
Fix blank scroll area when returning from Preferences to a running mode

### DIFF
--- a/Software/src/Version 6 and newer/m32_v6.ino
+++ b/Software/src/Version 6 and newer/m32_v6.ino
@@ -1391,6 +1391,10 @@ if (morseState == morseKeyer &&
        case 2:  MorsePreferences::setupPreferences(MorsePreferences::menuPtr);                               // double click shows the preferences menu (true would select a specific option only)
                 MorseOutput::clearDisplay();                                 // restore display
                 updateTopLine();
+                MorseOutput::refreshScrollArea(MorseOutput::relPos);         // clearDisplay() wiped the screen, but not
+                                                                              // textBuffer - repaint what was already
+                                                                              // there instead of leaving it blank until
+                                                                              // new output is generated on resume
                 if (morseState == morseGenerator || morseState == echoTrainer)
                     stopFlag = true;                                  // we stop what we had been doing
                 else


### PR DESCRIPTION
## Summary
- Found while testing #216: entering Preferences (double-click) from a running classic mode (e.g. Koch Trainer::CW Generator::Random) and leaving it again (long-press) left the scroll area blank - only the "Continue with paddle" status line at the top reappeared. The previously shown content only popped back once you resumed (paddle touch), at which point it briefly showed the *old* content alongside new output.
- Root cause: the double-click handler calls `MorseOutput::clearDisplay()` on return from `setupPreferences()`, which wipes the physical screen buffer but leaves the scroll-history `textBuffer` untouched. Nothing repainted the visible scroll lines from that buffer afterward.

## Fix
Call the existing `MorseOutput::refreshScrollArea()` right after the display is cleared - the same helper already used elsewhere (e.g. the scroll-mode toggle) to repaint the visible lines from `textBuffer`.

## Test plan
- [x] Built `heltec_wifi_lora_32_V2` (Classic M32) - succeeds
- [x] Built and flashed `pocketwroom` (M32 Pocket) to a physical device
- [x] Manually verified on the M32 Pocket: Koch Trainer::CW Generator::Random, a few rounds, into Preferences and back out - the prior scroll content is there immediately instead of only appearing on resume

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)